### PR TITLE
maven-enforcer-plugin rule to enforce native-image version

### DIFF
--- a/common/common/src/main/java/io/helidon/build/common/PathFinder.java
+++ b/common/common/src/main/java/io/helidon/build/common/PathFinder.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.common;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.helidon.build.common.logging.Log;
+
+/**
+ * Path utility class.
+ */
+public class PathFinder {
+
+    private static final String PATH_ENV_VAR = "PATH";
+    private static final List<String> WINDOWS_EXECUTABLE_EXTENSIONS = List.of("exe", "bin", "bat", "cmd", "ps1");
+    private static final boolean IS_WINDOWS = File.pathSeparatorChar != ':';
+    private static final Predicate<Path> VALID_PATH = p -> Files.exists(p) && Files.isDirectory(p);
+    private static final List<Path> PATH_ENTRIES =
+            Optional.ofNullable(System.getenv(PATH_ENV_VAR))
+                    .map(p -> Arrays.asList(p.split(File.pathSeparator)))
+                    .stream()
+                    .flatMap(Collection::stream)
+                    .map(Path::of)
+                    .filter(VALID_PATH)
+                    .collect(Collectors.toList());
+
+    private PathFinder() {
+    }
+
+    private static Stream<Path> entries(List<Optional<Path>> entries) {
+        return entries.stream()
+                .flatMap(Optional::stream)
+                .filter(VALID_PATH);
+    }
+
+    private static Path findWindowsCmd(Path dir, String cmd) {
+        return WINDOWS_EXECUTABLE_EXTENSIONS.stream()
+                .map((ext) -> dir.resolve(cmd + "." + ext))
+                .filter(Files::isRegularFile)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static Path findCmd(Path dir, String cmd) {
+        Log.debug("Searching for cmd: %s in %s", cmd, dir);
+        Path cmdFile = dir.resolve(cmd);
+        if (Files.isRegularFile(cmdFile)) {
+            return cmdFile;
+        }
+        return IS_WINDOWS ? findWindowsCmd(dir, cmd) : null;
+    }
+
+    /**
+     * Find file in the given path.
+     *
+     * @param fileName  file to be found
+     * @param overrides list of path to look for first
+     * @param extras    additional path
+     * @return path to the file
+     */
+    public static Optional<Path> find(String fileName, List<Optional<Path>> overrides, List<Optional<Path>> extras) {
+        return Stream.of(entries(overrides), PATH_ENTRIES.stream(), entries(extras))
+                .flatMap(Function.identity())
+                .flatMap(dir -> Optional.ofNullable(findCmd(dir, fileName)).stream())
+                .findFirst();
+    }
+}

--- a/common/common/src/main/java/io/helidon/build/common/PathFinder.java
+++ b/common/common/src/main/java/io/helidon/build/common/PathFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugins/enforcer-maven-plugin/pom.xml
+++ b/maven-plugins/enforcer-maven-plugin/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/maven-plugins/enforcer-maven-plugin/pom.xml
+++ b/maven-plugins/enforcer-maven-plugin/pom.xml
@@ -52,6 +52,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.helidon.build-tools.common</groupId>
+            <artifactId>helidon-build-common-maven</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
         </dependency>

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/EnforcerMojo.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/EnforcerMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/EnforcerMojo.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/EnforcerMojo.java
@@ -200,7 +200,7 @@ public class EnforcerMojo extends AbstractMojo {
             failuresByRule.forEach((rule, failures) -> {
                 Log.error("Rule $(magenta " + rule + ") failed. Errors:");
                 for (RuleFailure failure : failures) {
-                    Log.error(failure.print());
+                    Log.error(failure.toString());
                 }
             });
 
@@ -231,7 +231,7 @@ public class EnforcerMojo extends AbstractMojo {
                 failuresByRule.put("native-image", errors);
             } else {
                 for (RuleFailure error : errors) {
-                    Log.warn(error.print());
+                    Log.warn(error.toString());
                 }
             }
         }
@@ -260,7 +260,7 @@ public class EnforcerMojo extends AbstractMojo {
                 failuresByRule.put("typos", errors);
             } else {
                 for (RuleFailure error : errors) {
-                    Log.warn(error.print());
+                    Log.warn(error.toString());
                 }
             }
         }
@@ -290,7 +290,7 @@ public class EnforcerMojo extends AbstractMojo {
                 failuresByRule.put("copyright", errors);
             } else {
                 for (RuleFailure error : errors) {
-                    Log.warn(error.print());
+                    Log.warn(error.toString());
                 }
             }
         }

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/RuleFailure.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/RuleFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/RuleFailure.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/RuleFailure.java
@@ -78,12 +78,8 @@ public class RuleFailure {
         return line;
     }
 
-    /**
-     * Print Rule failure content.
-     *
-     * @return rule failure description
-     */
-    public String print() {
+    @Override
+    public String toString() {
         return fr != null
                 ? "  " + this.fr.relativePath() + ":" + this.line + ": " + this.message
                 : "  " + this.message;

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/RuleFailure.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/RuleFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,16 @@ public class RuleFailure {
     }
 
     /**
+     * Create new rule failure.
+     *
+     * @param message description of the failure
+     * @return a new rule failure
+     */
+    public static RuleFailure create(String message) {
+        return new RuleFailure(null, 0, message);
+    }
+
+    /**
      * File request.
      *
      * @return file request causing this failure
@@ -66,5 +76,16 @@ public class RuleFailure {
      */
     public int line() {
         return line;
+    }
+
+    /**
+     * Print Rule failure content.
+     *
+     * @return rule failure description
+     */
+    public String print() {
+        return fr != null
+                ? "  " + this.fr.relativePath() + ":" + this.line + ": " + this.message
+                : "  " + this.message;
     }
 }

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/EnforcerNativeImageException.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/EnforcerNativeImageException.java
@@ -19,10 +19,19 @@ import java.util.List;
 
 import io.helidon.build.common.Lists;
 
+/**
+ * Enforcer native-image exception.
+ */
 public class EnforcerNativeImageException extends RuntimeException {
 
-    EnforcerNativeImageException(String matcher, List<String> availableRules) {
-        super(String.format("Invalid matcher '%s'. Has to be one of: "
-                + Lists.join(availableRules, r -> r, ","), matcher));
+    /**
+     * Create a new enforcer native-image exception.
+     *
+     * @param matcher          invalid matcher
+     * @param availableMatcher list of valid matcher
+     */
+    EnforcerNativeImageException(String matcher, List<String> availableMatcher) {
+        super(String.format("Invalid matcher '%s'. Has to be one of: %s", matcher,
+                Lists.join(availableMatcher, r -> r, ",")));
     }
 }

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/EnforcerNativeImageException.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/EnforcerNativeImageException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.maven.enforcer.nativeimage;
+
+import java.util.List;
+
+import io.helidon.build.common.Lists;
+
+public class EnforcerNativeImageException extends RuntimeException {
+
+    EnforcerNativeImageException(String matcher, List<String> availableRules) {
+        super(String.format("Invalid matcher '%s'. Has to be one of: "
+                + Lists.join(availableRules, r -> r, ","), matcher));
+    }
+}

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/EnforcerNativeImageException.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/EnforcerNativeImageException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageConfig.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageConfig.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageConfig.java
@@ -21,6 +21,9 @@ import io.helidon.build.common.Lists;
 
 import org.apache.maven.plugins.annotations.Parameter;
 
+/**
+ * Native-image configuration.
+ */
 public class NativeImageConfig {
     /**
      * Fail if error found.

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageConfig.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageConfig.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.maven.enforcer.nativeimage;
+
+import java.util.List;
+
+import io.helidon.build.common.Lists;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+public class NativeImageConfig {
+    /**
+     * Fail if error found.
+     */
+    @Parameter(defaultValue = "false")
+    private boolean failOnError;
+
+    /**
+     * List of forbidden version.
+     */
+    @Parameter(required = true)
+    private List<VersionConfig> rules;
+
+    @Override
+    public String toString() {
+        return "NativeImageConfig{"
+                + "failOnError=" + failOnError
+                + ", versions=" + Lists.join(rules, Object::toString, ",")
+                + '}';
+    }
+
+    /**
+     * Fail if version does not respect rules.
+     *
+     * @return fail on error
+     */
+    public boolean failOnError() {
+        return failOnError;
+    }
+
+    /**
+     * Get rules.
+     *
+     * @return rules
+     */
+    public List<VersionConfig> rules() {
+        if (rules == null) {
+            return List.of();
+        }
+        return rules;
+    }
+}

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageRule.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageRule.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageRule.java
@@ -41,7 +41,7 @@ public class NativeImageRule {
     private final List<VersionConfig> versionConfigs;
 
     /**
-     * Constructor.
+     * Create a new native-image rule.
      *
      * @param config native-image configuration
      */

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageRule.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageRule.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.maven.enforcer.nativeimage;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.build.common.PathFinder;
+import io.helidon.build.common.maven.MavenVersion;
+import io.helidon.build.maven.enforcer.EnforcerException;
+import io.helidon.build.maven.enforcer.RuleFailure;
+
+import static io.helidon.build.common.maven.MavenVersion.toMavenVersion;
+
+/**
+ * Native image version rule.
+ */
+public class NativeImageRule {
+
+    private static final String NATIVE_IMAGE = "native-image";
+    private static final String GRAALVM_HOME = "GRAALVM_HOME";
+    private static final String JAVA_HOME = "JAVA_HOME";
+    private final List<VersionConfig> versionConfigs;
+
+    /**
+     * Constructor.
+     *
+     * @param config native-image configuration
+     */
+    public NativeImageRule(NativeImageConfig config) {
+        this.versionConfigs = config.rules();
+    }
+
+    /**
+     * Check native-image version.
+     *
+     * @return list of errors
+     */
+    public List<RuleFailure> check() {
+        List<RuleFailure> failures = new LinkedList<>();
+        Process process = startProcess();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith("GraalVM")) {
+                    checkVersion(failures, line.split(" "));
+                }
+            }
+        } catch (IOException e) {
+            throw new EnforcerException("Fail to run native-image --version");
+        }
+        return failures;
+    }
+
+    private void checkVersion(List<RuleFailure> failures, String[] elements) {
+        if (elements.length < 1) {
+            return;
+        }
+        MavenVersion version = toMavenVersion(elements[1]);
+        for (VersionConfig rule : versionConfigs) {
+            rule.checkVersion(version, failures);
+        }
+    }
+
+    private Process startProcess() {
+        Path nativeImage = findNativeImage();
+        if (nativeImage == null
+                || !nativeImage.toFile().exists()) {
+            throw new EnforcerException("native-image executable not found.");
+        }
+        ProcessBuilder builder = new ProcessBuilder(nativeImage.toString(), "--version")
+                .redirectErrorStream(true);
+
+        Process process;
+        try {
+            process = builder.start();
+        } catch (IOException e) {
+            throw new EnforcerException("Fail to run native-image --version");
+        }
+
+        try {
+            process.getOutputStream().close();
+        } catch (IOException ignored) {
+        }
+        return process;
+    }
+
+    private Path findNativeImage() {
+        return PathFinder.find(NATIVE_IMAGE,
+                        List.of(Optional.ofNullable(System.getenv(GRAALVM_HOME))
+                                .map(Path::of)
+                                .map(p -> p.resolve("bin"))),
+                        List.of(Optional.ofNullable(System.getenv(JAVA_HOME))
+                                .map(Path::of)
+                                .map(p -> p.resolve("bin"))))
+                .orElseThrow(() -> new IllegalStateException("Unable to find " + NATIVE_IMAGE));
+    }
+
+}

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/VersionConfig.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/VersionConfig.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.maven.enforcer.nativeimage;
+
+import java.util.List;
+
+import io.helidon.build.common.maven.MavenVersion;
+import io.helidon.build.maven.enforcer.RuleFailure;
+
+import static io.helidon.build.common.maven.MavenVersion.toMavenVersion;
+
+/**
+ * Version configuration.
+ */
+public class VersionConfig {
+
+    private String version;
+    private String matcher;
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getMatcher() {
+        return matcher;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public void setMatcher(String matcher) {
+        this.matcher = matcher;
+    }
+
+    private final List<String> availableMatcher = List.of(
+            "greaterThan",
+            "lessThan",
+            "greaterThanOrEqualTo",
+            "lessThanOrEqualTo");
+
+    /**
+     * Check versions against rule configuration.
+     *
+     * @param nativeVersion native-image version
+     * @param failures      list of errors
+     */
+    void checkVersion(MavenVersion nativeVersion, List<RuleFailure> failures) {
+        MavenVersion ruleVersion = toMavenVersion(getVersion());
+        boolean success;
+        switch (matcher.toLowerCase()) {
+            case "greaterthan":
+                success = nativeVersion.isGreaterThan(ruleVersion);
+                break;
+            case "lessthan":
+                success = nativeVersion.isLessThan(ruleVersion);
+                break;
+            case "greaterthanorequalto":
+                success = nativeVersion.isGreaterThanOrEqualTo(ruleVersion);
+                break;
+            case "lessthanorequalto":
+                success = nativeVersion.isLessThanOrEqualTo(ruleVersion);
+                break;
+            default:
+                throw new EnforcerNativeImageException(matcher, availableMatcher);
+        }
+        if (!success) {
+            failures.add(RuleFailure.create(errorMessage(matcher, nativeVersion, ruleVersion)));
+        }
+    }
+
+    private String errorMessage(String match, MavenVersion nativeVersion, MavenVersion ruleVersion) {
+        return String.format("native image version %s is not %s %s rule version.", nativeVersion, match, ruleVersion);
+    }
+
+    @Override
+    public String toString() {
+        return "VersionConfig{"
+                + "version=" + version
+                + ", matcher=" + matcher
+                + "}";
+    }
+}

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/VersionConfig.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/VersionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/VersionConfig.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/VersionConfig.java
@@ -30,23 +30,43 @@ public class VersionConfig {
     private String version;
     private String matcher;
 
+    /**
+     * Get version.
+     *
+     * @return version
+     */
     public String getVersion() {
         return version;
     }
 
+    /**
+     * Get matcher.
+     *
+     * @return matcher
+     */
     public String getMatcher() {
         return matcher;
     }
 
+    /**
+     * Set version.
+     *
+     * @param version version
+     */
     public void setVersion(String version) {
         this.version = version;
     }
 
+    /**
+     * Set matcher.
+     *
+     * @param matcher matcher
+     */
     public void setMatcher(String matcher) {
         this.matcher = matcher;
     }
 
-    private final List<String> availableMatcher = List.of(
+    private static final List<String> AVAILABLE_MATCHER = List.of(
             "greaterThan",
             "lessThan",
             "greaterThanOrEqualTo",
@@ -59,7 +79,7 @@ public class VersionConfig {
      * @param failures      list of errors
      */
     void checkVersion(MavenVersion nativeVersion, List<RuleFailure> failures) {
-        MavenVersion ruleVersion = toMavenVersion(getVersion());
+        MavenVersion ruleVersion = toMavenVersion(version);
         boolean success;
         switch (matcher.toLowerCase()) {
             case "greaterthan":
@@ -75,7 +95,7 @@ public class VersionConfig {
                 success = nativeVersion.isLessThanOrEqualTo(ruleVersion);
                 break;
             default:
-                throw new EnforcerNativeImageException(matcher, availableMatcher);
+                throw new EnforcerNativeImageException(matcher, AVAILABLE_MATCHER);
         }
         if (!success) {
             failures.add(RuleFailure.create(errorMessage(matcher, nativeVersion, ruleVersion)));

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/package-info.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/package-info.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Native image rules.
+ */
+package io.helidon.build.maven.enforcer.nativeimage;

--- a/maven-plugins/enforcer-maven-plugin/src/test/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageRuleTest.java
+++ b/maven-plugins/enforcer-maven-plugin/src/test/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugins/enforcer-maven-plugin/src/test/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageRuleTest.java
+++ b/maven-plugins/enforcer-maven-plugin/src/test/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageRuleTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.maven.enforcer.nativeimage;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import io.helidon.build.common.maven.MavenVersion;
+import io.helidon.build.maven.enforcer.RuleFailure;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.build.common.maven.MavenVersion.toMavenVersion;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class NativeImageRuleTest {
+
+    @Test
+    void testWrongMatcherConfiguration() {
+        VersionConfig config = createVersionConfig("dummy");
+        List<RuleFailure> failures = new LinkedList<>();
+        MavenVersion version = toMavenVersion("1.0.0");
+
+        try {
+            config.checkVersion(version, failures);
+        } catch (EnforcerNativeImageException e) {
+            assertThat(e.getMessage(), containsString("Invalid matcher"));
+            return;
+        }
+        fail("Exception must have been thrown");
+    }
+
+    @Test
+    void testGreaterThanRuleConfiguration() {
+        VersionConfig config = createVersionConfig("greaterThan");
+        List<RuleFailure> failures = new LinkedList<>();
+        MavenVersion version = toMavenVersion("1.0.0");
+
+        config.checkVersion(version, failures);
+        assertThat(failures.size(), is(1));
+
+        config.setVersion("2.0.0");
+        config.checkVersion(version, failures);
+        assertThat(failures.size(), is(2));
+
+        config.setVersion("0.1.0");
+        config.checkVersion(version, failures);
+        assertThat(failures.size(), is(2));
+    }
+
+    @Test
+    void testLessThanRuleConfiguration() {
+        VersionConfig config = createVersionConfig("lessThan");
+        List<RuleFailure> failures = new LinkedList<>();
+        MavenVersion version = toMavenVersion("1.0.0");
+
+        config.checkVersion(version, failures);
+        assertThat(failures.size(), is(1));
+
+        config.setVersion("2.0.0");
+        config.checkVersion(version, failures);
+        assertThat(failures.size(), is(1));
+
+        config.setVersion("0.1.0");
+        config.checkVersion(version, failures);
+        assertThat(failures.size(), is(2));
+    }
+
+    @Test
+    void testGreaterThanOrEqualToRuleConfiguration() {
+        VersionConfig config = createVersionConfig("greaterThanOrEqualTo");
+        List<RuleFailure> failures = new LinkedList<>();
+        MavenVersion version = toMavenVersion("1.0.0");
+
+        config.checkVersion(version, failures);
+        assertThat(failures.size(), is(0));
+
+        config.setVersion("2.0.0");
+        config.checkVersion(version, failures);
+        assertThat(failures.size(), is(1));
+
+        config.setVersion("0.1.0");
+        config.checkVersion(version, failures);
+        assertThat(failures.size(), is(1));
+    }
+
+    @Test
+    void testLessThanOrEqualToRuleConfiguration() {
+        VersionConfig config = createVersionConfig("lessThanOrEqualTo");
+        List<RuleFailure> failures = new LinkedList<>();
+        MavenVersion version = toMavenVersion("1.0.0");
+
+        config.checkVersion(version, failures);
+        assertThat(failures.size(), is(0));
+
+        config.setVersion("2.0.0");
+        config.checkVersion(version, failures);
+        assertThat(failures.size(), is(0));
+
+        config.setVersion("0.1.0");
+        config.checkVersion(version, failures);
+        assertThat(failures.size(), is(1));
+    }
+
+    private VersionConfig createVersionConfig(String match) {
+        VersionConfig config = new VersionConfig();
+        config.setVersion("1.0.0");
+        config.setMatcher(match);
+        return config;
+    }
+}

--- a/maven-plugins/enforcer-maven-plugin/src/test/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageRuleTest.java
+++ b/maven-plugins/enforcer-maven-plugin/src/test/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageRuleTest.java
@@ -28,6 +28,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
+/**
+ * Native-image enforcer rul tests.
+ */
 public class NativeImageRuleTest {
 
     @Test

--- a/maven-plugins/helidon-maven-plugin/src/main/java/io/helidon/build/maven/GraalNativeMojo.java
+++ b/maven-plugins/helidon-maven-plugin/src/main/java/io/helidon/build/maven/GraalNativeMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
fix #781

Configuration looks like this: 

```
<nativeImageConfig>
    <failOnError>true</failOnError>
    <rules>
        <rule>
            <version>2.0.0</version>
            <matcher>greaterThan</matcher>
        </rule>
        <rule>
            <version>3.0.0</version>
            <matcher>lessThan</matcher>
        </rule>
    </rules>
</nativeImageConfig>
```