### PR TITLE
Fix GitIgnore on Windows.

### DIFF
--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/GitIgnore.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/GitIgnore.java
@@ -24,6 +24,8 @@ import java.util.regex.Pattern;
 
 import io.helidon.build.common.logging.Log;
 
+import static io.helidon.build.common.Strings.normalizePath;
+
 /**
  * Utility class for gitignore parsing.
  */
@@ -142,7 +144,7 @@ class GitIgnore implements FileMatcher {
 
     private boolean isParentExcluded(String pattern) {
         pattern = "/" + pattern;
-        Path parent = Path.of(pattern).getParent();
+        String parent = normalizePath(Path.of(pattern).getParent().toString());
         if (!parent.endsWith("/")) {
             pattern = parent + "/";
         }


### PR DESCRIPTION
Use `Strings.normalizePath` when using `java.nio.Path`. 
Fixes #903