### PR TITLE
fix  helidon-cli-functional module test

### DIFF
--- a/cli/impl/pom.xml
+++ b/cli/impl/pom.xml
@@ -168,13 +168,6 @@
                         </manifest>
                     </archive>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/cli/tests/functional/pom.xml
+++ b/cli/tests/functional/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -43,16 +43,6 @@
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>io.helidon.build-tools</groupId>
-            <artifactId>helidon-archetype-maven-plugin</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.build-tools</groupId>
-            <artifactId>helidon-stager-maven-plugin</artifactId>
-            <version>${project.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>io.helidon.build-tools.common</groupId>
@@ -64,13 +54,6 @@
             <groupId>io.helidon.build-tools.cli</groupId>
             <artifactId>helidon-cli-impl</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.build-tools.cli</groupId>
-            <artifactId>helidon-cli-impl</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -112,16 +95,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-jar</id>
-                        <phase>test-compile</phase>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
@@ -136,7 +109,6 @@
                 <executions>
                     <execution>
                         <goals>
-                            <goal>install</goal>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>

--- a/cli/tests/functional/src/test/java/io/helidon/build/cli/tests/CliFunctionalV2Test.java
+++ b/cli/tests/functional/src/test/java/io/helidon/build/cli/tests/CliFunctionalV2Test.java
@@ -16,16 +16,6 @@
 
 package io.helidon.build.cli.tests;
 
-import io.helidon.build.cli.impl.Helidon;
-import io.helidon.build.common.ProcessMonitor;
-import io.helidon.build.common.Strings;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -36,13 +26,24 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import io.helidon.build.cli.impl.Helidon;
+import io.helidon.build.common.ProcessMonitor;
+import io.helidon.build.common.Strings;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import static io.helidon.build.cli.tests.FunctionalUtils.getProperty;
+import static io.helidon.build.cli.tests.FunctionalUtils.setMavenLocalRepoUrl;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 
 public class CliFunctionalV2Test {
 
     private static String expectedOutput;
-
     private static Path workDir;
     private static Path helidonShell;
     private static Path helidonBatch;
@@ -51,9 +52,9 @@ public class CliFunctionalV2Test {
 
     @BeforeAll
     static void setup() throws IOException {
-        FunctionalUtils.setMavenLocalRepoUrl();
+        setMavenLocalRepoUrl();
         Path input = Files.createTempFile("input","txt");
-        Path executableDir = Path.of(FunctionalUtils.getProperty("helidon.executable.directory"));
+        Path executableDir = Path.of(getProperty("helidon.executable.directory"));
         workDir = Files.createTempDirectory("generated");
         inputFile = Files.writeString(input, "\n\n\n").toFile();
         helidonBatch = executableDir.resolve("helidon.bat");

--- a/cli/tests/functional/src/test/java/io/helidon/build/cli/tests/CliMavenTest.java
+++ b/cli/tests/functional/src/test/java/io/helidon/build/cli/tests/CliMavenTest.java
@@ -16,6 +16,17 @@
 
 package io.helidon.build.cli.tests;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
 import io.helidon.build.cli.impl.Helidon;
 import io.helidon.build.common.FileUtils;
 import io.helidon.build.common.ProcessMonitor;
@@ -29,19 +40,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
-
 import static io.helidon.build.cli.tests.FunctionalUtils.ARCHETYPE_URL;
 import static io.helidon.build.cli.tests.FunctionalUtils.CLI_VERSION;
+import static io.helidon.build.cli.tests.FunctionalUtils.downloadMavenDist;
+import static io.helidon.build.cli.tests.FunctionalUtils.setMavenLocalRepoUrl;
 import static io.helidon.build.cli.tests.FunctionalUtils.validateSeProject;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -60,12 +62,11 @@ public class CliMavenTest {
 
     @BeforeAll
     static void setUp() throws IOException {
-        FunctionalUtils.setMavenLocalRepoUrl();
+        setMavenLocalRepoUrl();
         workDir = Files.createTempDirectory("generated");
         mavenDirectory = Files.createTempDirectory("maven");
-
         for (String version : MAVEN_VERSIONS) {
-            FunctionalUtils.downloadMavenDist(mavenDirectory, version);
+            downloadMavenDist(mavenDirectory, version);
         }
     }
 

--- a/cli/tests/pom.xml
+++ b/cli/tests/pom.xml
@@ -37,10 +37,6 @@
                 <property>
                     <name>!skipTests</name>
                 </property>
-                <os>
-                    <!-- https://github.com/helidon-io/helidon-build-tools/issues/898 -->
-                    <family>unix</family>
-                </os>
             </activation>
             <modules>
                 <module>functional</module>


### PR DESCRIPTION
fix #898

It contains fix and clean up of unused code like the `test-jar` that was created for functional test in the first place and became unused after functional test refactoring.