### PR TITLE
Improve layout of helidon.zip

### DIFF
--- a/cli/impl/pom.xml
+++ b/cli/impl/pom.xml
@@ -168,6 +168,25 @@
                         </manifest>
                     </archive>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>cli-distribution</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration combine.self="override">
+                            <classifier>cli</classifier>
+                            <archive>
+                                <manifest>
+                                    <addClasspath>true</addClasspath>
+                                    <mainClass>${mainClass}</mainClass>
+                                    <useUniqueVersions>false</useUniqueVersions>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/cli/impl/src/main/assembly/distribution.xml
+++ b/cli/impl/src/main/assembly/distribution.xml
@@ -28,7 +28,7 @@
     <fileSets>
         <fileSet>
             <directory>${project.build.directory}/libs</directory>
-            <outputDirectory>/lib/libs</outputDirectory>
+            <outputDirectory>/lib</outputDirectory>
             <includes>
                 <include>*.jar</include>
             </includes>
@@ -36,7 +36,7 @@
     </fileSets>
     <files>
         <file>
-            <source>${project.build.directory}/helidon.jar</source>
+            <source>${project.build.directory}/helidon-cli.jar</source>
             <outputDirectory>/lib</outputDirectory>
         </file>
         <file>

--- a/cli/impl/src/main/assembly/helidon
+++ b/cli/impl/src/main/assembly/helidon
@@ -73,7 +73,7 @@ build_command() {
         shift
     done
 
-    command="${JAVA_EXEC} ${HELIDON_JAVA_OPS} -jar ${BASEDIR}/lib/helidon.jar ${args}"
+    command="${JAVA_EXEC} ${HELIDON_JAVA_OPS} -jar ${BASEDIR}/lib/helidon-cli.jar ${args}"
 }
 
 #Append variable value

--- a/cli/impl/src/main/assembly/helidon.bat
+++ b/cli/impl/src/main/assembly/helidon.bat
@@ -23,7 +23,7 @@ if "%JAVACMD%"=="" set JAVACMD=java
 @REM Find script base directory
 for %%i in ("%~dp0..") do set "BASEDIR=%%~fi"
 
-set JARFILE=%BASEDIR%\lib\helidon.jar
+set JARFILE=%BASEDIR%\lib\helidon-cli.jar
 set ARGS=
 
 for %%x in (%*) do (

--- a/cli/tests/functional/src/test/java/io/helidon/build/cli/tests/CliDistributionTest.java
+++ b/cli/tests/functional/src/test/java/io/helidon/build/cli/tests/CliDistributionTest.java
@@ -76,11 +76,10 @@ public class CliDistributionTest {
         //Ensure main directory are present
         assertThat(content, hasItems(DIST_BASE_DIR + "/bin"));
         assertThat(content, hasItems(DIST_BASE_DIR + "/lib"));
-        assertThat(content, hasItems(DIST_BASE_DIR + "/lib/libs"));
         //Ensure main files are present
         assertThat(content, hasItems(DIST_BASE_DIR + "/bin/helidon"));
         assertThat(content, hasItems(DIST_BASE_DIR + "/bin/helidon.bat"));
-        assertThat(content, hasItems(DIST_BASE_DIR + "/lib/helidon.jar"));
+        assertThat(content, hasItems(DIST_BASE_DIR + "/lib/helidon-cli.jar"));
         assertThat(content, hasItems(DIST_BASE_DIR + "/LICENSE.txt"));
     }
 


### PR DESCRIPTION
Introduce a new cli jar `helidon-cli.jar` used for distribution. 

This way, helidon.jar with associated `libs/` and scripts can be used to ease the dev process.

resolves #942