### PR TITLE
Revert jandex 3

### DIFF
--- a/linker/pom.xml
+++ b/linker/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/linker/pom.xml
+++ b/linker/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.smallrye</groupId>
+            <groupId>org.jboss</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
         <dependency>

--- a/linker/src/main/java/module-info.java
+++ b/linker/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/linker/src/main/java/module-info.java
+++ b/linker/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ module helidon.linker {
 
     requires jdk.jlink;
     requires jdk.jdeps;
-    requires org.jboss.jandex;
+    requires jandex;
     requires org.fusesource.jansi;
     requires org.objectweb.asm;
     requires io.helidon.build.common;

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
         <version.lib.invoker>3.0.1</version.lib.invoker>
         <version.lib.jackson>2.11.0</version.lib.jackson>
-        <version.lib.jandex>3.1.2</version.lib.jandex>
+        <version.lib.jandex>2.1.1.Final</version.lib.jandex>
         <version.lib.jansi>1.18</version.lib.jansi>
         <version.lib.jaxb-api>2.3.3</version.lib.jaxb-api>
         <version.lib.jaxb-core>2.3.0.1</version.lib.jaxb-core>
@@ -756,7 +756,7 @@
                 <version>${version.lib.mustache}</version>
             </dependency>
             <dependency>
-                <groupId>io.smallrye</groupId>
+                <groupId>org.jboss</groupId>
                 <artifactId>jandex</artifactId>
                 <version>${version.lib.jandex}</version>
             </dependency>


### PR DESCRIPTION
Build-tools 3.x needs to remain compatible with Helidon 3.x
Back-out the jandex 3 update from master, we will add it again once we branch-off for 4.x