### PR TITLE
Update cli finalName to helidon-cli

### DIFF
--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -29,6 +29,10 @@ inputs:
     description:  Wether to cache the Maven build (read-only or read-write)
     required: false
     default: ''
+  build-cache-id:
+    description:  Build cache id
+    required: false
+    default: 'default'
   GPG_PASSPHRASE:
     description: Value of the GPG_PASSPHRASE environment variable
     required: false
@@ -105,11 +109,10 @@ runs:
         git config --global core.eol lf
     - name: Set up GraalVM
       if: ${{ inputs.native-image == 'true' }}
-      uses: graalvm/setup-graalvm@v1
+      uses: graalvm/setup-graalvm@v1.1.2.1
       with:
         java-version: ${{ env.JAVA_VERSION }}
         version: ${{ env.GRAALVM_VERSION }}
-        distribution: 'graalvm'
         components: 'native-image'
         check-for-updates: 'false'
         set-java-home: 'false'
@@ -148,8 +151,9 @@ runs:
           ./**/target/**
           .m2/repository/io/helidon/build-tools/**
         enableCrossOsArchive: true
-        key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
+        key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.build-cache-id }}
         restore-keys: |
+          build-cache-${{ github.run_id }}-${{ github.run_attempt }}-
           build-cache-${{ github.run_id }}-
     - name: Build cache (read-only)
       if: ${{ inputs.build-cache == 'read-only' }}
@@ -160,8 +164,9 @@ runs:
           .m2/repository/io/helidon/build-tools/**
         enableCrossOsArchive: true
         fail-on-cache-miss: true
-        key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
+        key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.build-cache-id }}
         restore-keys: |
+          build-cache-${{ github.run_id }}-${{ github.run_attempt }}-
           build-cache-${{ github.run_id }}-
     - name: Populate Maven cache
       if: ${{ inputs.maven-cache == 'read-write' }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,7 +29,7 @@ on:
 env:
   JAVA_VERSION: 17
   JAVA_DISTRO: oracle
-  GRAALVM_VERSION: 21.3.0
+  GRAALVM_VERSION: 21.3.3.1
   MAVEN_ARGS: |
     -B -fae -e
     -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
@@ -87,7 +87,7 @@ jobs:
           build-cache: read-write
           maven-cache: read-write
           artifact-name: helidon-cli
-          artifact-path: cli/impl/target/helidon.zip
+          artifact-path: cli/impl/target/helidon-cli.zip
           run: |
             mvn ${MAVEN_ARGS} -T 8 \
               -DskipTests \
@@ -171,7 +171,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
         with:
-          build-cache: read-only
+          build-cache: read-write
           run: |
             mvn ${MAVEN_ARGS} \
               -pl ide-support/vscode-extension \
@@ -189,6 +189,7 @@ jobs:
             platform: linux-amd64
           - os: windows-2022
             platform: windows-amd64
+            file-ext: .exe
           - os: macos-12
             platform: darwin-amd64
     runs-on: ${{ matrix.os }}
@@ -203,21 +204,21 @@ jobs:
           native-image: true
           archive-test-results: true
           artifact-name: helidon-cli
-          artifact-path: cli/impl/target/helidon-${{ matrix.platform }}*
+          artifact-path: cli/impl/target/helidon-cli-${{ matrix.platform }}${{ matrix.file-ext }}
           run: |
             # build the executable
             mvn ${MAVEN_ARGS} \
               -pl cli/impl \
               -DskipTests \
               -Pnative-image,!toolchain \
-              -Dnative.image.name=helidon-${{ matrix.platform }} \
+              -Dnative.image.name=helidon-cli-${{ matrix.platform }} \
               package
 
             # smoke test
             mvn ${MAVEN_ARGS} \
               -pl cli/tests/functional \
               -Pnative-image \
-              -Dnative.image.name=helidon-${{ matrix.platform }} \
+              -Dnative.image.name=helidon-cli-${{ matrix.platform }} \
               -Dsurefire.reportNameSuffix=native-image-${{ matrix.platform }} \
               -Dtest=CliFunctionalV2Test#*Native* \
               test

--- a/cli/impl/helidon.bat
+++ b/cli/impl/helidon.bat
@@ -1,5 +1,5 @@
 @REM
-@REM Copyright (c) 2022 Oracle and/or its affiliates.
+@REM Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 @REM
 @REM Licensed under the Apache License, Version 2.0 (the "License");
 @REM you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 
 set projectDir=%~dp0
 set targetDir=%projectDir%target
-set jarFile=%targetDir%\helidon.jar
+set jarFile=%targetDir%\helidon-cli.jar
 set attach="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005"
 set attachMvn="-Dmvn.debug.port=5006"
 set attachMvnChild="-Dmvn.child.debug.port=5007"

--- a/cli/impl/helidon.sh
+++ b/cli/impl/helidon.sh
@@ -26,7 +26,7 @@ main() {
 init() {
     local -r projectDir=$(dirname "${0}")
     local -r targetDir="${projectDir}/target/"
-    local -r jarFile="${targetDir}/helidon.jar"
+    local -r jarFile="${targetDir}/helidon-cli.jar"
     local -r attach="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005"
     local -r attachMvn="-Dmvn.debug.port=5006"
     local -r attachMvnChild="-Dmvn.child.debug.port=5007"

--- a/cli/impl/pom.xml
+++ b/cli/impl/pom.xml
@@ -123,7 +123,7 @@
     </dependencies>
 
     <build>
-        <finalName>helidon</finalName>
+        <finalName>helidon-cli</finalName>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
@@ -167,26 +167,6 @@
                         </manifest>
                     </archive>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>cli-distribution</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration combine.self="override">
-                            <outputDirectory>${project.build.directory}/libs</outputDirectory>
-                            <classifier>cli</classifier>
-                            <archive>
-                                <manifest>
-                                    <addClasspath>true</addClasspath>
-                                    <mainClass>${mainClass}</mainClass>
-                                    <useUniqueVersions>false</useUniqueVersions>
-                                </manifest>
-                            </archive>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -242,7 +222,6 @@
         <profile>
             <id>native-image</id>
             <properties>
-                <build.dir>${project.build.directory}</build.dir>
                 <native.image.name>${project.build.finalName}</native.image.name>
             </properties>
             <build>
@@ -267,35 +246,32 @@
                                             <destFileName>cli-plugins-${buildNumber}.jar</destFileName>
                                         </artifactItem>
                                     </artifactItems>
-                                    <outputDirectory>${build.dir}/native/plugins</outputDirectory>
+                                    <outputDirectory>${project.build.directory}/native/plugins</outputDirectory>
                                 </configuration>
                             </execution>
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <phase>package</phase>
                                 <id>native-image</id>
+                                <phase>package</phase>
                                 <goals>
-                                    <goal>exec</goal>
+                                    <goal>compile-no-fork</goal>
                                 </goals>
                                 <configuration>
-                                    <executable>native-image</executable>
-                                    <arguments>
-                                        <argument>-H:Path=${build.dir}</argument>
-                                        <argument>-H:Name=${native.image.name}</argument>
-                                        <argument>-H:+PrintAnalysisCallTree</argument>
-                                        <argument>--install-exit-handlers</argument>
-                                        <argument>--no-fallback</argument>
-                                        <argument>-cp</argument>
-                                        <argument>
-                                            ${build.dir}${file.separator}${native.image.name}.jar${path.separator}${build.dir}${file.separator}libs${file.separator}*${path.separator}${build.dir}${file.separator}native
-                                        </argument>
-                                        <argument>${mainClass}</argument>
-                                    </arguments>
+                                    <imageName>${native.image.name}</imageName>
+                                    <fallback>false</fallback>
+                                    <classpath>
+                                        <entry>${project.build.directory}/helidon-cli.jar</entry>
+                                        <entry>${project.build.directory}/libs</entry>
+                                        <entry>${project.build.directory}/native</entry>
+                                    </classpath>
+                                    <buildArgs>
+                                        <arg>--install-exit-handlers</arg>
+                                    </buildArgs>
                                 </configuration>
                             </execution>
                         </executions>

--- a/cli/impl/src/main/assembly/distribution.xml
+++ b/cli/impl/src/main/assembly/distribution.xml
@@ -28,13 +28,18 @@
     <fileSets>
         <fileSet>
             <directory>${project.build.directory}/libs</directory>
-            <outputDirectory>/lib</outputDirectory>
+            <outputDirectory>/libs</outputDirectory>
             <includes>
                 <include>*.jar</include>
             </includes>
         </fileSet>
     </fileSets>
     <files>
+        <file>
+            <source>${project.build.directory}/helidon-cli.jar</source>
+            <outputDirectory>/</outputDirectory>
+            <fileMode>0555</fileMode>
+        </file>
         <file>
             <source>${project.basedir}/src/main/assembly/helidon.bat</source>
             <outputDirectory>/bin</outputDirectory>

--- a/cli/impl/src/main/assembly/helidon
+++ b/cli/impl/src/main/assembly/helidon
@@ -73,7 +73,7 @@ build_command() {
         shift
     done
 
-    command="${JAVA_EXEC} ${HELIDON_JAVA_OPS} -jar ${BASEDIR}/lib/helidon-cli.jar ${args}"
+    command="${JAVA_EXEC} ${HELIDON_JAVA_OPS} -jar ${BASEDIR}/helidon-cli.jar ${args}"
 }
 
 #Append variable value

--- a/cli/impl/src/main/assembly/helidon.bat
+++ b/cli/impl/src/main/assembly/helidon.bat
@@ -23,7 +23,7 @@ if "%JAVACMD%"=="" set JAVACMD=java
 @REM Find script base directory
 for %%i in ("%~dp0..") do set "BASEDIR=%%~fi"
 
-set JARFILE=%BASEDIR%\lib\helidon-cli.jar
+set JARFILE=%BASEDIR%\helidon-cli.jar
 set ARGS=
 
 for %%x in (%*) do (

--- a/cli/impl/src/main/resources/META-INF/native-image/io.helidon.build-tools.cli/helidon-cli-impl/native-image.properties
+++ b/cli/impl/src/main/resources/META-INF/native-image/io.helidon.build-tools.cli/helidon-cli-impl/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cli/tests/functional/src/test/java/io/helidon/build/cli/tests/CliDistributionTest.java
+++ b/cli/tests/functional/src/test/java/io/helidon/build/cli/tests/CliDistributionTest.java
@@ -59,7 +59,7 @@ public class CliDistributionTest {
         distDir = Files.createTempDirectory("dist");
         Path targetDir = Path.of(getProperty("helidon.executable.directory"));
         LOGGER.info("targetDir - " + targetDir.toRealPath());
-        Path cliZip = targetDir.resolve("target/helidon.zip");
+        Path cliZip = targetDir.resolve("target/helidon-cli.zip");
         LOGGER.info("cliZip - " + cliZip.toRealPath());
         unzip(cliZip, distDir);
     }
@@ -75,11 +75,11 @@ public class CliDistributionTest {
 
         //Ensure main directory are present
         assertThat(content, hasItems(DIST_BASE_DIR + "/bin"));
-        assertThat(content, hasItems(DIST_BASE_DIR + "/lib"));
+        assertThat(content, hasItems(DIST_BASE_DIR + "/libs"));
         //Ensure main files are present
         assertThat(content, hasItems(DIST_BASE_DIR + "/bin/helidon"));
         assertThat(content, hasItems(DIST_BASE_DIR + "/bin/helidon.bat"));
-        assertThat(content, hasItems(DIST_BASE_DIR + "/lib/helidon-cli.jar"));
+        assertThat(content, hasItems(DIST_BASE_DIR + "/helidon-cli.jar"));
         assertThat(content, hasItems(DIST_BASE_DIR + "/LICENSE.txt"));
     }
 

--- a/cli/tests/functional/src/test/java/io/helidon/build/cli/tests/FunctionalUtils.java
+++ b/cli/tests/functional/src/test/java/io/helidon/build/cli/tests/FunctionalUtils.java
@@ -159,7 +159,7 @@ public class FunctionalUtils {
     }
 
     static List<String> buildJavaCommand() {
-        Path jar = Path.of(getProperty("helidon.executable.directory")).resolve("target/helidon.jar");
+        Path jar = Path.of(getProperty("helidon.executable.directory")).resolve("target/helidon-cli.jar");
         return new ArrayList<>(List.of(javaPath(), "-Xmx128M", "-jar", jar.toString()));
     }
 

--- a/ide-support/vscode-extension/gulpfile.js
+++ b/ide-support/vscode-extension/gulpfile.js
@@ -18,7 +18,7 @@ const gulp = require('gulp');
 
 gulp.task('build', (done) => {
     gulp.src('../../cli/impl/target/libs/**/*').pipe(gulp.dest('./target/cli/libs'));
-    gulp.src('../../cli/impl/target/helidon.jar').pipe(gulp.dest('./target/cli'));
+    gulp.src('../../cli/impl/target/helidon-cli.jar').pipe(gulp.dest('./target/cli'));
     gulp.src('../lsp/lsp-server/target/helidon-lsp-server.jar').pipe(gulp.dest('./target/server'));
     gulp.src('../lsp/lsp-server/target/libs/*').pipe(gulp.dest('./target/server/libs'));
     gulp.src('../lsp/lsp-server/etc/logging.properties').pipe(gulp.dest('./target/server'));

--- a/ide-support/vscode-extension/src/generator.ts
+++ b/ide-support/vscode-extension/src/generator.ts
@@ -61,7 +61,7 @@ export async function showHelidonGenerator(extensionPath: string) {
         VSCodeAPI.showInformationMessage('Your Helidon project is being created...');
 
         const archetypeValues = prepareProperties(projectData);
-        const cmd = `java -jar ${extensionPath}/target/cli/helidon.jar init --batch \
+        const cmd = `java -jar ${extensionPath}/target/cli/helidon-cli.jar init --batch \
             ${archetypeValues}`;
 
         channel.appendLine(cmd);

--- a/ide-support/vscode-extension/src/helidonDev.ts
+++ b/ide-support/vscode-extension/src/helidonDev.ts
@@ -164,7 +164,7 @@ function configEnvPath(configPath: string, binPath: string, pathDelimiter: strin
 
 function obtainNewServerProcess(helidonProjectDir: string, extensionPath: string): ChildProcess {
     const cmdSpan = "java";
-    const args = ['-jar', `${extensionPath}/target/cli/helidon.jar`, 'dev'];
+    const args = ['-jar', `${extensionPath}/target/cli/helidon-cli.jar`, 'dev'];
 
     const pathDelimiter = path.delimiter;
 

--- a/pom.xml
+++ b/pom.xml
@@ -184,12 +184,12 @@
         <version.plugin.dependency>3.3.0</version.plugin.dependency>
         <version.plugin.deploy>2.8.2</version.plugin.deploy>
         <version.plugin.enforcer>3.0.0-M1</version.plugin.enforcer>
-        <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>3.0.0-M5</version.plugin.failsafe>
         <version.plugin.findsecbugs>1.11.0</version.plugin.findsecbugs>
         <version.plugin.frontend>1.11.3</version.plugin.frontend>
         <version.plugin.glassfish-copyright>2.3</version.plugin.glassfish-copyright>
         <version.plugin.gpg>1.6</version.plugin.gpg>
+        <version.plugin.graalvm>0.9.23</version.plugin.graalvm>
         <version.plugin.jacoco>0.7.9</version.plugin.jacoco>
         <version.plugin.jar>3.0.2</version.plugin.jar>
         <version.plugin.javadoc>3.2.0</version.plugin.javadoc>
@@ -316,11 +316,6 @@
                             <version>${version.lib.junit}</version>
                         </dependency>
                     </dependencies>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>exec-maven-plugin</artifactId>
-                    <version>${version.plugin.exec}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -505,6 +500,11 @@
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>
                     <version>${version.plugin.frontend}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.graalvm.buildtools</groupId>
+                    <artifactId>native-maven-plugin</artifactId>
+                    <version>${version.plugin.graalvm}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
- Fix references to helidon.jar and helidon.zip
- Converge on a single layout (helidon-cli.jar and libs)
- Update release.sh to pass args
- Added a build-cache-id option to support multiple build-cache for a workflow (E.g. default, javadoc)
- Uptake org.graalvm.buildtools:native-maven-plugin to build the native cli
- Fix usage of setup-graalvm action to download legacy graalvm (binary size is bigger with newer versions)
- add file-ext matrix include to file only the cli binaries in the helidon-cli artifact