### PR TITLE
Properly sort archetype version

### DIFF
--- a/cli/common/src/main/java/io/helidon/build/cli/common/SemVer.java
+++ b/cli/common/src/main/java/io/helidon/build/cli/common/SemVer.java
@@ -49,14 +49,14 @@ final class SemVer {
     static List<String> latestMajorVersions(List<ArchetypesData.Version> versions) {
         List<String> ids = versions.stream().map(ArchetypesData.Version::id).collect(Collectors.toList());
         // versions grouped by major digit
-        Map<String, List<String>> groups = Lists.mappedBy(ids, SemVer::majorDigit);
+        Map<String, List<String>> groups = Lists.mappedBy(ids, SemVer::lowestVersionFromMajorDigit);
 
         // Maven versions grouped by version range
         Map<VersionRange, List<MavenVersion>> ranges =
                 Maps.mapEntry(groups, Strings::isValid, VersionRange::higherOrEqual, MavenVersion::toMavenVersion);
 
         // the latest of each group
-        Collection<MavenVersion> latest = Maps.mapEntryValue(ranges, entry->entry.getKey().resolveLatest(entry.getValue()))
+        Collection<MavenVersion> latest = Maps.mapEntryValue(ranges, entry -> entry.getKey().resolveLatest(entry.getValue()))
                                               .values();
         List<ArchetypesData.Version> latestVersions = versions.stream()
                 .filter(version -> latest.contains(version.toMavenVersion()))
@@ -72,10 +72,10 @@ final class SemVer {
         return versions;
     }
 
-    private static String majorDigit(String version) {
+    private static String lowestVersionFromMajorDigit(String version) {
         Matcher matcher = MAJOR_PATTERN.matcher(version);
         if (matcher.find()) {
-            return matcher.group("major");
+            return matcher.group("major") + "-SNAPSHOT";
         }
         return "";
     }

--- a/cli/common/src/test/java/io/helidon/build/cli/common/ArchetypesDataTest.java
+++ b/cli/common/src/test/java/io/helidon/build/cli/common/ArchetypesDataTest.java
@@ -88,6 +88,30 @@ public class ArchetypesDataTest {
                 Matchers.is(List.of("2.0.0", "1.0.1", "4.0.0")));
     }
 
+    @Test
+    public void testVersionQualifierOrdering() {
+        String version1;
+        String version2;
+        List<String> versions = List.of(
+                "1.0-SNAPSHOT",
+                "1.0-ALPHA",
+                "1.0-BETA",
+                "1.0-MILESTONE",
+                "1.0-RC",
+                "1.0",
+                "1.0-sp");
+
+        for (int i = 0; i < versions.size() - 1; i += 2) {
+            version1 = versions.get(i);
+            version2 = versions.get(i + 1);
+            assertThat(String.format("%s should be picked over %s", version1, version2),
+                    data(version(version1, 100),
+                            version(version2, 100))
+                            .latestMajorVersions(),
+                    Matchers.is(List.of(version2)));
+        }
+    }
+
     private static ArchetypesData data(ArchetypesData.Version... versions) {
         return ArchetypesData.builder().versions(versions).build();
     }

--- a/cli/common/src/test/java/io/helidon/build/cli/common/ArchetypesDataTest.java
+++ b/cli/common/src/test/java/io/helidon/build/cli/common/ArchetypesDataTest.java
@@ -101,7 +101,7 @@ public class ArchetypesDataTest {
                 "1.0",
                 "1.0-sp");
 
-        for (int i = 0; i < versions.size() - 1; i += 2) {
+        for (int i = 0; i < versions.size() - 1; i++) {
             version1 = versions.get(i);
             version2 = versions.get(i + 1);
             assertThat(String.format("%s should be picked over %s", version1, version2),

--- a/common/common/src/main/java/io/helidon/build/common/Maps.java
+++ b/common/common/src/main/java/io/helidon/build/common/Maps.java
@@ -432,9 +432,9 @@ public class Maps {
             Function<T, K> keyMapper,
             Function<U, V> valueMapper) {
         return map.entrySet().stream()
-                  .filter(entry-> keyFilter.test(entry.getKey()))
+                  .filter(entry -> keyFilter.test(entry.getKey()))
                   .collect(Collectors.toMap(
-                          entry->keyMapper.apply(entry.getKey()),
-                          entry->entry.getValue().stream().map(valueMapper).collect(Collectors.toList())));
+                          entry -> keyMapper.apply(entry.getKey()),
+                          entry -> entry.getValue().stream().map(valueMapper).collect(Collectors.toList())));
     }
 }

--- a/common/maven/src/main/java/io/helidon/build/common/maven/ComparableVersion.java
+++ b/common/maven/src/main/java/io/helidon/build/common/maven/ComparableVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -259,11 +259,11 @@ class ComparableVersion implements Comparable<ComparableVersion> {
     private static class StringItem implements Item {
 
         private static final List<String> QUALIFIERS = Arrays.asList(
+                "snapshot",
                 "alpha",
                 "beta",
                 "milestone",
                 "rc",
-                "snapshot",
                 "",
                 "sp");
 

--- a/common/maven/src/test/java/io/helidon/build/common/maven/MavenVersionTest.java
+++ b/common/maven/src/test/java/io/helidon/build/common/maven/MavenVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package io.helidon.build.common.maven;
+
+import java.util.List;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -81,5 +83,26 @@ class MavenVersionTest {
         assertThat(toMavenVersion("2.0.0-RC1"), is(org.hamcrest.Matchers.greaterThan(toMavenVersion("2.0.0-M4"))));
         assertThat(toMavenVersion("2.0.0-RC2"), is(org.hamcrest.Matchers.greaterThan(toMavenVersion("2.0.0-RC1"))));
         assertThat(toMavenVersion("2.0.0"), is(org.hamcrest.Matchers.greaterThan(toMavenVersion("2.0.0-RC2"))));
+    }
+
+    @Test
+    void testQualifierComparison() {
+        MavenVersion version1;
+        MavenVersion version2;
+        List<MavenVersion> versions = List.of(
+                toMavenVersion("0-SNAPSHOT"),
+                toMavenVersion("0-ALPHA"),
+                toMavenVersion("0-BETA"),
+                toMavenVersion("0-MILESTONE"),
+                toMavenVersion("0-RC"),
+                toMavenVersion("0"),
+                toMavenVersion("0-sp"));
+
+        for (int i = 0; i < versions.size() - 1; i += 2) {
+            version1 = versions.get(i);
+            version2 = versions.get(i + 1);
+            assertThat(String.format("%s should be lower than %s", version1, version2),
+                    version1, is(org.hamcrest.Matchers.lessThan(version2)));
+        }
     }
 }

--- a/common/maven/src/test/java/io/helidon/build/common/maven/MavenVersionTest.java
+++ b/common/maven/src/test/java/io/helidon/build/common/maven/MavenVersionTest.java
@@ -98,7 +98,7 @@ class MavenVersionTest {
                 toMavenVersion("0"),
                 toMavenVersion("0-sp"));
 
-        for (int i = 0; i < versions.size() - 1; i += 2) {
+        for (int i = 0; i < versions.size() - 1; i++) {
             version1 = versions.get(i);
             version2 = versions.get(i + 1);
             assertThat(String.format("%s should be lower than %s", version1, version2),


### PR DESCRIPTION
Fix #974

In addition to this work, the https://helidon.io/cli-data/versions.xml has to be updated. The lower version should be qualified with `snapshot`.

From:
```xml
<rule archetype="[2.0.0,3.0.0)" cli="[2.0.0,5.0.0)"/>
```
to
```xml
<rule archetype="[2.0.0-snapshot,3.0.0)" cli="[2.0.0-snapshot,5.0.0)"/>
```

Otherwise most of the qualified version are out of the range.