### PR TITLE
Improve Maven archetype compatibility testing to prevent uncaught cla…

### DIFF
--- a/cli/tests/functional/src/it/settings.xml
+++ b/cli/tests/functional/src/it/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,9 +20,6 @@
     <profiles>
         <profile>
             <id>it-repo</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <repositories>
                 <repository>
                     <id>local.central</id>
@@ -51,4 +48,7 @@
             </pluginRepositories>
         </profile>
     </profiles>
+    <activeProfiles>
+        <activeProfile>it-repo</activeProfile>
+    </activeProfiles>
 </settings>

--- a/dev-loop/dev-loop/src/it/settings.xml
+++ b/dev-loop/dev-loop/src/it/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,9 +20,6 @@
     <profiles>
         <profile>
             <id>it-repo</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <repositories>
                 <repository>
                     <id>local.central</id>
@@ -49,4 +46,7 @@
             </pluginRepositories>
         </profile>
     </profiles>
+    <activeProfiles>
+        <activeProfile>it-repo</activeProfile>
+    </activeProfiles>
 </settings>

--- a/maven-plugins/build-cache-maven-plugin/src/it/settings.xml
+++ b/maven-plugins/build-cache-maven-plugin/src/it/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,9 +20,6 @@
     <profiles>
         <profile>
             <id>it-repo</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <repositories>
                 <repository>
                     <id>local.central</id>
@@ -49,4 +46,7 @@
             </pluginRepositories>
         </profile>
     </profiles>
+    <activeProfiles>
+        <activeProfile>it-repo</activeProfile>
+    </activeProfiles>
 </settings>

--- a/maven-plugins/enforcer-maven-plugin/src/it/settings.xml
+++ b/maven-plugins/enforcer-maven-plugin/src/it/settings.xml
@@ -20,9 +20,6 @@
     <profiles>
         <profile>
             <id>it-repo</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <repositories>
                 <repository>
                     <id>local.central</id>
@@ -49,4 +46,7 @@
             </pluginRepositories>
         </profile>
     </profiles>
+    <activeProfiles>
+        <activeProfile>it-repo</activeProfile>
+    </activeProfiles>
 </settings>

--- a/maven-plugins/helidon-archetype-maven-plugin/etc/spotbugs/exclude.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/etc/spotbugs/exclude.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -55,6 +55,12 @@
     <Match>
         <!-- Method creates a java.net.URLClassLoader classloader, which should be performed within a doPrivileged block -->
         <Class name="io.helidon.build.maven.archetype.postgenerate.EngineFacade"/>
+        <Bug pattern="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED"/>
+    </Match>
+
+    <Match>
+        <!-- Method creates a java.net.URLClassLoader classloader, which should be performed within a doPrivileged block -->
+        <Class name="io.helidon.build.maven.archetype.ReflectionHelper"/>
         <Bug pattern="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED"/>
     </Match>
 

--- a/maven-plugins/helidon-archetype-maven-plugin/pom.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/pom.xml
@@ -34,15 +34,6 @@
         <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>org.eclipse.sisu.plexus</artifactId>
-                <version>0.3.5</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.helidon.build-tools.archetype</groupId>
@@ -133,11 +124,6 @@
             <artifactId>helidon-build-common-test-utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-archetype-plugin</artifactId>
-            <version>3.2.1</version>
         </dependency>
     </dependencies>
 

--- a/maven-plugins/helidon-archetype-maven-plugin/pom.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/pom.xml
@@ -34,6 +34,15 @@
         <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.sisu</groupId>
+                <artifactId>org.eclipse.sisu.plexus</artifactId>
+                <version>0.3.5</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.helidon.build-tools.archetype</groupId>
@@ -125,10 +134,26 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-archetype-plugin</artifactId>
+            <version>3.2.1</version>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-component-metadata</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-metadata</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/maven-plugins/helidon-archetype-maven-plugin/src/it/settings.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/it/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,9 +20,6 @@
     <profiles>
         <profile>
             <id>it-repo</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <repositories>
                 <repository>
                     <id>local.central</id>
@@ -51,4 +48,7 @@
             </pluginRepositories>
         </profile>
     </profiles>
+    <activeProfiles>
+        <activeProfile>it-repo</activeProfile>
+    </activeProfiles>
 </settings>

--- a/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/MavenArchetypeGenerator.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/MavenArchetypeGenerator.java
@@ -70,7 +70,11 @@ class MavenArchetypeGenerator {
                 .setProjectBuildingRequest(session.getProjectBuildingRequest());
 
         ArchetypeGenerationResult result = new ArchetypeGenerationResult();
+
+        Thread currentThread = Thread.currentThread();
+        ClassLoader ccl = currentThread.getContextClassLoader();
         try {
+            currentThread.setContextClassLoader(container.getLookupRealm());
             ArchetypeGenerator generator = container.lookup(ArchetypeGenerator.class);
             generator.generateArchetype(request, archetypeFile, result);
             if (result.getCause() != null) {
@@ -83,6 +87,8 @@ class MavenArchetypeGenerator {
             }
         } catch (ComponentLookupException e) {
             throw new RuntimeException(e);
+        } finally {
+            currentThread.setContextClassLoader(ccl);
         }
     }
 }

--- a/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/MavenArchetypeGenerator.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/MavenArchetypeGenerator.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.maven.archetype;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import org.apache.maven.archetype.ArchetypeGenerationRequest;
+import org.apache.maven.archetype.ArchetypeGenerationResult;
+import org.apache.maven.archetype.exception.ArchetypeNotConfigured;
+import org.apache.maven.archetype.generator.ArchetypeGenerator;
+import org.apache.maven.execution.MavenSession;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+
+/**
+ * Generate a project using {@link ArchetypeGenerator}.
+ */
+class MavenArchetypeGenerator {
+
+    private MavenArchetypeGenerator() {
+    }
+
+    /**
+     * Generate a new project.
+     *
+     * @param container           plexus container
+     * @param archetypeGroupId    archetype groupId
+     * @param archetypeArtifactId archetype artifactId
+     * @param archetypeVersion    archetype version
+     * @param archetypeFile       archetype file
+     * @param properties          archetype properties
+     * @param basedir             project base directory
+     * @param session             Maven session
+     */
+    @SuppressWarnings({"unused", "checkstyle:ParameterNumber"})
+    static void generate(PlexusContainer container,
+                         String archetypeGroupId,
+                         String archetypeArtifactId,
+                         String archetypeVersion,
+                         File archetypeFile,
+                         Properties properties,
+                         Path basedir,
+                         MavenSession session) {
+
+        ArchetypeGenerationRequest request = new ArchetypeGenerationRequest()
+                .setArchetypeGroupId(archetypeGroupId)
+                .setArchetypeArtifactId(archetypeArtifactId)
+                .setArchetypeVersion(archetypeVersion)
+                .setGroupId(properties.getProperty("groupId"))
+                .setArtifactId(properties.getProperty("artifactId"))
+                .setVersion(properties.getProperty("version"))
+                .setPackage(properties.getProperty("package"))
+                .setOutputDirectory(basedir.toString())
+                .setProperties(properties)
+                .setProjectBuildingRequest(session.getProjectBuildingRequest());
+
+        ArchetypeGenerationResult result = new ArchetypeGenerationResult();
+        try {
+            ArchetypeGenerator generator = container.lookup(ArchetypeGenerator.class);
+            generator.generateArchetype(request, archetypeFile, result);
+            if (result.getCause() != null) {
+                if (result.getCause() instanceof ArchetypeNotConfigured) {
+                    ArchetypeNotConfigured anc = (ArchetypeNotConfigured) result.getCause();
+                    throw new RuntimeException(
+                            "Missing required properties in archetype.properties: "
+                                    + String.join(", ", anc.getMissingProperties()), anc);
+                }
+            }
+        } catch (ComponentLookupException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/MojoHelper.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/MojoHelper.java
@@ -38,21 +38,19 @@ final class MojoHelper {
      */
     static final String PLUGIN_ARTIFACT_ID = "helidon-archetype-maven-plugin";
 
-    private static final String MAVEN_ARCHETYPE_PLUGIN_GROUP_ID = "org.apache.maven.plugins";
-    private static final String MAVEN_ARCHETYPE_PLUGIN_ARTIFACT_ID = "maven-archetype-plugin";
-    private static final String MAVEN_ARCHETYPE_PLUGIN_VERSION = version(MAVEN_ARCHETYPE_PLUGIN_GROUP_ID,
-                                                                         MAVEN_ARCHETYPE_PLUGIN_ARTIFACT_ID);
+    private static final String MAVEN_ARCHETYPE_VERSION = version("org.apache.maven.archetype", "archetype-common");
 
     /**
      * The Maven archetype plugin coordinates.
      */
-    static final Plugin MAVEN_ARCHETYPE_PLUGIN = plugin(MAVEN_ARCHETYPE_PLUGIN_GROUP_ID,
-                                                        MAVEN_ARCHETYPE_PLUGIN_ARTIFACT_ID,
-                                                        MAVEN_ARCHETYPE_PLUGIN_VERSION);
+    static final Plugin MAVEN_ARCHETYPE_PLUGIN = plugin("org.apache.maven.plugins",
+                                                        "maven-archetype-plugin",
+                                                        MAVEN_ARCHETYPE_VERSION);
 
     private MojoHelper() {
     }
 
+    @SuppressWarnings("SameParameterValue")
     private static String version(String groupId, String artifactId) {
         try {
             String path = String.format("/META-INF/maven/%s/%s/pom.properties", groupId, artifactId);
@@ -74,6 +72,7 @@ final class MojoHelper {
         }
     }
 
+    @SuppressWarnings("SameParameterValue")
     private static Plugin plugin(String groupId, String artifactId, String version) {
         Plugin plugin = new Plugin();
         plugin.setGroupId(groupId);

--- a/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/PluginContainerManager.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/PluginContainerManager.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.maven.archetype;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.classrealm.ClassRealmManager;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.PluginResolutionException;
+import org.apache.maven.plugin.internal.PluginDependenciesResolver;
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.DefaultContainerConfiguration;
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusConstants;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.configuration.PlexusConfigurationException;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator;
+
+import static org.apache.maven.RepositoryUtils.toArtifacts;
+
+/**
+ * A plexus component to create plexus containers for plugins.
+ */
+@Component(role = PluginContainerManager.class, hint = "default")
+public class PluginContainerManager {
+
+    @Requirement
+    private ClassRealmManager classRealmManager;
+
+    @Requirement
+    private PluginDependenciesResolver pluginDependenciesResolver;
+
+    /**
+     * Create a new plexus container for a given plugin.
+     *
+     * @param plugin      plugin coordinates
+     * @param repos       remote plugin repositories
+     * @param repoSession repository session
+     * @return plexus container
+     */
+    @SuppressWarnings("SameParameterValue")
+    public PlexusContainer create(Plugin plugin, List<RemoteRepository> repos, RepositorySystemSession repoSession) {
+        try {
+            ClassRealm classRealm = pluginClassRealm(plugin, repos, repoSession);
+            ContainerConfiguration containerConfiguration = new DefaultContainerConfiguration();
+            containerConfiguration.setAutoWiring(true);
+            containerConfiguration.setClassPathScanning(PlexusConstants.SCANNING_INDEX);
+            containerConfiguration.setRealm(classRealm);
+            PlexusContainer container = new DefaultPlexusContainer(containerConfiguration);
+            Deque<ClassRealm> stack = new ArrayDeque<>();
+            stack.push(classRealm);
+            while (!stack.isEmpty()) {
+                ClassRealm realm = stack.pop();
+                container.discoverComponents(realm);
+                realm.getImportRealms().forEach(stack::push);
+            }
+            return container;
+        } catch (PlexusContainerException | PlexusConfigurationException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private ClassRealm pluginClassRealm(Plugin plugin, List<RemoteRepository> repos, RepositorySystemSession repoSession) {
+        try {
+            Map<String, ClassLoader> foreignImports = Map.of("", classRealmManager.getMavenApiRealm());
+            List<Artifact> artifacts = resolvePluginDependencies(plugin, repos, repoSession);
+            return classRealmManager.createPluginRealm(plugin, null, null, foreignImports, artifacts);
+        } catch (PluginResolutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private List<org.eclipse.aether.artifact.Artifact> resolvePluginDependencies(Plugin plugin,
+                                                                                 List<RemoteRepository> repos,
+                                                                                 RepositorySystemSession repoSession)
+            throws PluginResolutionException {
+
+        org.eclipse.aether.artifact.Artifact pluginArtifact = new DefaultArtifact(
+                plugin.getGroupId(), plugin.getArtifactId(), "jar", plugin.getVersion());
+
+        DependencyNode root = pluginDependenciesResolver.resolve(plugin, pluginArtifact, null, repos, repoSession);
+        return new ArrayList<>(toArtifacts(expandDependency(root)));
+    }
+
+    private static List<org.apache.maven.artifact.Artifact> expandDependency(DependencyNode node) {
+        PreorderNodeListGenerator visitor = new PreorderNodeListGenerator();
+        node.accept(visitor);
+        List<org.apache.maven.artifact.Artifact> artifacts = new ArrayList<>(visitor.getNodes().size());
+        toArtifacts(artifacts, List.of(node), List.of(), null);
+        artifacts.removeIf(artifact -> artifact.getFile() == null);
+        return Collections.unmodifiableList(artifacts);
+    }
+}

--- a/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/ReflectionHelper.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/ReflectionHelper.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.maven.archetype;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+
+/**
+ * Reflection helper.
+ */
+class ReflectionHelper {
+
+    private ReflectionHelper() {
+    }
+
+    /**
+     * Invoke a static method via reflection.
+     *
+     * @param classLoader class loader
+     * @param className   class name
+     * @param methodName  method name
+     * @param args        arguments
+     * @return invocation return value
+     */
+    @SuppressWarnings({"UnusedReturnValue", "SameParameterValue"})
+    static Object invokeMethod(ClassLoader classLoader, String className, String methodName, Object... args) {
+        ClassLoader ccl = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(classLoader);
+        try {
+            ClassLoader cl = new ByteArrayClassLoader(classLoader);
+            Class<?> clazz = cl.loadClass(className);
+            Class<?>[] paramTypes = new Class<?>[args.length];
+            for (int i = 0; i < args.length; i++) {
+                paramTypes[i] = args[i].getClass();
+            }
+            Method method = findMethod(clazz, methodName, paramTypes);
+            method.setAccessible(true);
+            return method.invoke(null, args);
+        } catch (ClassNotFoundException
+                 | NoSuchMethodException
+                 | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException ex) {
+            Throwable cause = ex.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            throw new RuntimeException(ex.getCause());
+        } finally {
+            Thread.currentThread().setContextClassLoader(ccl);
+        }
+    }
+
+    private static Method findMethod(Class<?> clazz, String methodName, Class<?>... paramTypes) throws NoSuchMethodException {
+        for (Method method : clazz.getDeclaredMethods()) {
+            Class<?>[] actualParamTypes = method.getParameterTypes();
+            if (actualParamTypes.length == paramTypes.length) {
+                boolean found = true;
+                for (int i = 0; i < actualParamTypes.length; i++) {
+                    if (!actualParamTypes[i].isAssignableFrom(paramTypes[i])) {
+                        found = false;
+                        break;
+                    }
+                }
+                if (found) {
+                    return method;
+                }
+            }
+        }
+        throw new NoSuchMethodException(clazz.getName() + "." + methodName);
+    }
+
+    private static class ByteArrayClassLoader extends ClassLoader {
+
+        ByteArrayClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public Class<?> findClass(String name) throws ClassNotFoundException {
+            byte[] bytes = classBytes(name);
+            if (bytes != null && bytes.length > 0) {
+                return defineClass(name, bytes, 0, bytes.length);
+            }
+            return super.findClass(name);
+        }
+
+        private byte[] classBytes(String name) {
+            URL resource = getClass().getResource("/" + name.replace('.', '/') + ".class");
+            if (resource == null) {
+                return new byte[0];
+            }
+            try (InputStream is = resource.openStream()) {
+                return is.readAllBytes();
+            } catch (IOException ex) {
+                throw new UncheckedIOException(ex);
+            }
+        }
+    }
+}

--- a/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/ReflectionHelper.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/ReflectionHelper.java
@@ -41,8 +41,6 @@ class ReflectionHelper {
      */
     @SuppressWarnings({"UnusedReturnValue", "SameParameterValue"})
     static Object invokeMethod(ClassLoader classLoader, String className, String methodName, Object... args) {
-        ClassLoader ccl = Thread.currentThread().getContextClassLoader();
-        Thread.currentThread().setContextClassLoader(classLoader);
         try {
             ClassLoader cl = new ByteArrayClassLoader(classLoader);
             Class<?> clazz = cl.loadClass(className);
@@ -63,8 +61,6 @@ class ReflectionHelper {
                 throw (RuntimeException) cause;
             }
             throw new RuntimeException(ex.getCause());
-        } finally {
-            Thread.currentThread().setContextClassLoader(ccl);
         }
     }
 

--- a/maven-plugins/helidon-maven-plugin/src/it/settings.xml
+++ b/maven-plugins/helidon-maven-plugin/src/it/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,9 +20,6 @@
     <profiles>
         <profile>
             <id>it-repo</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <repositories>
                 <repository>
                     <id>local.central</id>
@@ -49,4 +46,7 @@
             </pluginRepositories>
         </profile>
     </profiles>
+    <activeProfiles>
+        <activeProfile>it-repo</activeProfile>
+    </activeProfiles>
 </settings>

--- a/maven-plugins/stager-maven-plugin/src/it/settings.xml
+++ b/maven-plugins/stager-maven-plugin/src/it/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,9 +20,6 @@
     <profiles>
         <profile>
             <id>it-repo</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <repositories>
                 <repository>
                     <id>local.central</id>
@@ -49,4 +46,7 @@
             </pluginRepositories>
         </profile>
     </profiles>
+    <activeProfiles>
+        <activeProfile>it-repo</activeProfile>
+    </activeProfiles>
 </settings>


### PR DESCRIPTION
Improve Maven archetype compatibility testing to prevent uncaught class loading issues

- Create a classloader that matches the official Maven archetype plugin
- Create a Plexus container to invoke the code that uses `AchetypeGenerator` to generate the projects
- Update all invoker tests settings.xml to use activeProfiles instead of activeByDefault=true

Compliments #983