### PR TITLE
small fix in apply matching

### DIFF
--- a/maven-enforcer-rules/src/main/java/io/helidon/build/maven/enforcer/rules/DependencyIsValidCheck.java
+++ b/maven-enforcer-rules/src/main/java/io/helidon/build/maven/enforcer/rules/DependencyIsValidCheck.java
@@ -60,11 +60,11 @@ class DependencyIsValidCheck implements Function<Artifact, Boolean> {
 
     @Override
     public Boolean apply(Artifact gav) {
-        String groupPackageName = toPackage(gav.getGroupId());
-        if (isExcluded(groupPackageName)) {
+        if (isExcluded(toSimpleGav(gav))) {
             return true;
         }
 
+        String groupPackageName = toPackage(gav.getGroupId());
         if (groupPackageName.equals("javax.servlet")
                 || groupPackageName.equals("jakarta.servlet")) {
             return false;
@@ -113,7 +113,7 @@ class DependencyIsValidCheck implements Function<Artifact, Boolean> {
         List<String> violations = new ArrayList<>();
         for (Artifact gav : gavs) {
             if (!apply(gav)) {
-                violations.add(gav.getGroupId() + ":" + gav.getArtifactId() + ":" + gav.getVersion());
+                violations.add(toSimpleGav(gav));
             }
         }
 
@@ -214,6 +214,10 @@ class DependencyIsValidCheck implements Function<Artifact, Boolean> {
             throw new UncheckedIOException(e);
         }
         return props;
+    }
+
+    static String toSimpleGav(Artifact gav) {
+        return gav.getGroupId() + ":" + gav.getArtifactId() + ":" + gav.getVersion();
     }
 
 }

--- a/maven-enforcer-rules/src/test/java/io/helidon/build/maven/enforcer/rules/DependencyIsValidCheckTest.java
+++ b/maven-enforcer-rules/src/test/java/io/helidon/build/maven/enforcer/rules/DependencyIsValidCheckTest.java
@@ -19,6 +19,9 @@ package io.helidon.build.maven.enforcer.rules;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -83,6 +86,21 @@ class DependencyIsValidCheckTest {
                    is(false));
         assertThat(dependencyIsValidCheckForJavax.apply("javax.inject:javax.inject:1"),
                    is(true));
+    }
+
+    @Test
+    void testArtifactApply() {
+        DependencyIsValidCheck dependencyIsValidCheckForJakarta =
+                new DependencyIsValidCheck(HelidonDependenciesRule.JAKARTA,
+                                           List.of(Pattern.compile("jakarta.servlet:jakarta.servlet-api.*")));
+        Artifact artifact = new DefaultArtifact("jakarta.servlet",
+                                                "jakarta.servlet-api",
+                                                "2.1.0",
+                                                "",
+                                                "",
+                                                "",
+                                                null);
+        assertThat(dependencyIsValidCheckForJakarta.apply(artifact), is((true)));
     }
 
     @Test


### PR DESCRIPTION
This will properly check the entire simple gav (g:a:v) instead of just validating an `Artifact` using its group.