### PR TITLE
OptimizedWalker should skip conditions if the nested node is skipped

### DIFF
--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ArchetypeEngineV2.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/ArchetypeEngineV2.java
@@ -58,9 +58,15 @@ public class ArchetypeEngineV2 {
     /**
      * Generate a project.
      *
+     * @param externalValues external values
+     * @param externalDefaults external defaults
+     * @param directorySupplier directory supplier
      * @return output directory
      */
-    public Path generate() {
+    public Path generate(Map<String, String> externalValues,
+                         Map<String, String> externalDefaults,
+                         Function<String, Path> directorySupplier) {
+
         Context context = Context.builder()
                                  .cwd(cwd)
                                  .externalValues(externalValues)
@@ -92,6 +98,15 @@ public class ArchetypeEngineV2 {
         }
 
         return directory;
+    }
+
+    /**
+     * Generate a project.
+     *
+     * @return output directory
+     */
+    public Path generate() {
+        return generate(externalValues, externalDefaults, directorySupplier);
     }
 
     /**

--- a/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/OptimizedWalker.java
+++ b/archetype/engine-v2/src/main/java/io/helidon/build/archetype/engine/v2/util/OptimizedWalker.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import io.helidon.build.archetype.engine.v2.Walker;
 import io.helidon.build.archetype.engine.v2.ast.Block;
+import io.helidon.build.archetype.engine.v2.ast.Condition;
 import io.helidon.build.archetype.engine.v2.ast.DeclaredBlock;
 import io.helidon.build.archetype.engine.v2.ast.Invocation;
 import io.helidon.build.archetype.engine.v2.ast.Node;
@@ -114,6 +115,14 @@ public class OptimizedWalker<T> implements Node.Visitor<Void> {
             default:
                 return postVisitAny(block, arg);
         }
+    }
+
+    @Override
+    public Node.VisitResult visitCondition(Condition condition, Void arg) {
+        if (isSkipped(condition.then())) {
+            return Node.VisitResult.SKIP_SUBTREE;
+        }
+        return condition.accept(visitor, this.visitorArg);
     }
 
     @Override

--- a/archetype/engine-v2/src/test/resources/compiler/empty-script/main.xml
+++ b/archetype/engine-v2/src/test/resources/compiler/empty-script/main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
         <inputs>
             <enum id="enum1" name="Enum1">
                 <option value="enum1-value1" name="Enum1Value1">
-                    <exec src="script1.xml"/>
+                    <exec src="script1.xml" if="true"/>
                 </option>
                 <option value="enum1-value2" name="Enum1Value2"/>
             </enum>


### PR DESCRIPTION
- Fix OptimizedWalker to skip condition if the nested node is skipped
- Overload ArchetypeV2.generate to expose a variant that accepts externalValues, externalDefaults and directorySupplier This allows to avoid creating a new instance of the engine for every project generation

Fixes #994