### PR TITLE
Fix issues related to helidon 4.0 CLI.

### DIFF
--- a/ide-support/vscode-extension/src/Interpreter.ts
+++ b/ide-support/vscode-extension/src/Interpreter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ide-support/vscode-extension/src/Interpreter.ts
+++ b/ide-support/vscode-extension/src/Interpreter.ts
@@ -224,10 +224,12 @@ export class Interpreter {
     private processVariables(element: any) {
         if (element.children) {
             for (const child of element.children) {
-                const expressionResult = Expression.create(this.archetype.expressions[child.if])
-                    .eval((val: string) => this.generatorData.context.lookup(val));
-                if (expressionResult === true) {
-                    this.generatorData.context.variables.set(child.path, child.value);
+                if (this.archetype.expressions[child.if]) {
+                    const expressionResult = Expression.create(this.archetype.expressions[child.if])
+                        .eval((val: string) => this.generatorData.context.lookup(val));
+                    if (expressionResult === true) {
+                        this.generatorData.context.variables.set(child.path, child.value);
+                    }
                 }
             }
         }

--- a/ide-support/vscode-extension/src/generator.ts
+++ b/ide-support/vscode-extension/src/generator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ide-support/vscode-extension/src/generator.ts
+++ b/ide-support/vscode-extension/src/generator.ts
@@ -61,7 +61,7 @@ export async function showHelidonGenerator(extensionPath: string) {
         VSCodeAPI.showInformationMessage('Your Helidon project is being created...');
 
         const archetypeValues = prepareProperties(projectData);
-        const cmd = `java -jar ${extensionPath}/target/cli/helidon-cli.jar init --batch \
+        const cmd = `java -jar ${extensionPath}/target/cli/helidon-cli.jar --plain init --batch \
             ${archetypeValues}`;
 
         channel.appendLine(cmd);


### PR DESCRIPTION
Fix issues found running with Helidon 4.x release CLI

- Switched to using --plain output for CLI to avoid encoding issues with color UI.
- Fix parsing archetype instructions.