### PR TITLE
Resolve variables in list-file "dir" attribute.

### DIFF
--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/ListFilesTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/ListFilesTask.java
@@ -78,7 +78,7 @@ final class ListFilesTask extends StagingTask implements TextAction {
 
     @Override
     protected void doExecute(StagingContext ctx, Path dir, Map<String, String> vars) {
-        Path resolved = dir.resolve(dirName);
+        Path resolved = dir.resolve(resolveVar(dirName, vars));
         List<Path> files = walk(resolved, FILE_VISIT_OPTIONS, this::filter);
         for (Path file : files) {
             String entry = normalizePath(dir.relativize(file));


### PR DESCRIPTION
Fix an issue where iterator variables are not substituted in the "dir" attribute of the new "list-files" task.

E.g.
```xml
<file target="listing.txt">
    <iterators>
        <variables>
            <variable name="category">
                <value>sport</value>
                <value>nature</value>
            </variable>
        </variables>
    </iterators>
    <list-files dir="images/{category}">
        <includes>
            <include>**/*.jpg</include>
        </includes>
    </list-files>
</file>
```