### PR TITLE
Use FileUtils.ensureDirectory instead of Files.createDirectories

### DIFF
--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/CopyArtifactTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/CopyArtifactTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import io.helidon.build.common.Maps;
+
+import static io.helidon.build.common.FileUtils.ensureDirectory;
 
 /**
  * Copy an artifact to a given target location.
@@ -54,7 +56,7 @@ final class CopyArtifactTask extends StagingTask {
         ctx.logInfo("Copying %s to %s", resolvedGav, resolveTarget);
         Path artifact = ctx.resolve(resolvedGav);
         Path targetFile = dir.resolve(resolveTarget);
-        Files.createDirectories(targetFile.getParent());
+        ensureDirectory(targetFile.getParent());
         Files.copy(artifact, targetFile);
     }
 

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/DownloadTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/DownloadTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import io.helidon.build.common.NetworkConnection;
 import io.helidon.build.common.Strings;
 
+import static io.helidon.build.common.FileUtils.ensureDirectory;
 import static io.helidon.build.common.FileUtils.measuredSize;
 
 /**
@@ -66,7 +67,7 @@ final class DownloadTask extends StagingTask {
     private void download(StagingContext ctx, Path dir, Map<String, String> vars) throws IOException {
         String path = resolveVar(target(), vars);
         Path file = dir.resolve(path).normalize();
-        Files.createDirectories(file.getParent());
+        ensureDirectory(file.getParent());
         URL url = new URL(resolveVar(this.url, vars));
         try (BufferedInputStream bis = new BufferedInputStream(open(url, ctx))) {
             try (OutputStream fos = Files.newOutputStream(file)) {

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/FileTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/FileTask.java
@@ -22,6 +22,8 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
+import static io.helidon.build.common.FileUtils.ensureDirectory;
+
 /**
  * Generate or copy a file to a given target location.
  */
@@ -68,7 +70,7 @@ final class FileTask extends StagingTask {
         String resolvedSource = resolveVar(source, vars);
         String resolvedContent = resolveVar(content, vars);
         Path targetFile = dir.resolve(resolvedTarget).normalize();
-        Files.createDirectories(targetFile.getParent());
+        ensureDirectory(targetFile.getParent());
         if (resolvedSource != null && !resolvedSource.isEmpty()) {
             Path sourceFile = ctx.resolve(resolvedSource);
             if (!Files.exists(sourceFile)) {

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingDirectory.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingDirectory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
  */
 package io.helidon.build.maven.stager;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+
+import static io.helidon.build.common.FileUtils.ensureDirectory;
 
 /**
  * Generate a directory using a set of actions.
@@ -39,8 +39,8 @@ class StagingDirectory extends StagingTask {
         Path targetDir = dir.resolve(target());
         ctx.logInfo("Staging %s", targetDir);
         try {
-            Files.createDirectories(targetDir);
-        } catch (IOException ex) {
+            ensureDirectory(targetDir);
+        } catch (Throwable ex) {
             return CompletableFuture.failedFuture(ex);
         }
         return super.execute(ctx, targetDir, vars);

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/SymlinkTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/SymlinkTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import io.helidon.build.common.Strings;
+
+import static io.helidon.build.common.FileUtils.ensureDirectory;
 
 /**
  * Create a symlink.
@@ -54,7 +56,7 @@ final class SymlinkTask extends StagingTask {
         Path link = dir.resolve(resolveVar(target(), vars));
         Path linkTarget = link.getParent().relativize(dir.resolve(resolveVar(source, vars)));
         ctx.logInfo("Creating symlink source: %s, target: %s", link, linkTarget);
-        Files.createDirectories(link.getParent());
+        ensureDirectory(link.getParent());
         Files.createSymbolicLink(link, linkTarget);
     }
 }

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/TemplateTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/TemplateTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import io.helidon.build.common.Strings;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.util.DecoratedCollection;
 
+import static io.helidon.build.common.FileUtils.ensureDirectory;
 import static java.util.stream.Collectors.toMap;
 
 /**
@@ -74,7 +75,7 @@ final class TemplateTask extends StagingTask {
             throw new IllegalStateException(sourceFile + " does not exist");
         }
         Path targetFile = dir.resolve(resolvedTarget).normalize();
-        Files.createDirectories(targetFile.getParent());
+        ensureDirectory(targetFile.getParent());
         try (Reader reader = Files.newBufferedReader(sourceFile);
              Writer writer = Files.newBufferedWriter(targetFile,
                      StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/UnpackArtifactTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/UnpackArtifactTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,10 @@
 package io.helidon.build.maven.stager;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+
+import static io.helidon.build.common.FileUtils.ensureDirectory;
 
 /**
  * Unpack an artifact to a given target location.
@@ -73,7 +74,7 @@ final class UnpackArtifactTask extends StagingTask {
         Path artifact = ctx.resolve(resolvedGav);
         Path targetDir = dir.resolve(resolvedTarget).normalize();
         ctx.logInfo("Unpacking %s to %s", artifact, targetDir);
-        Files.createDirectories(targetDir);
+        ensureDirectory(targetDir);
         ctx.unpack(artifact, targetDir, excludes, includes);
     }
 }


### PR DESCRIPTION
Update stager plugin tasks to use FileUtils.ensureDirectory instead of Files.createDirectories.