### PR TITLE
Make maven-archiver compile scope 

### DIFF
--- a/maven-plugins/sitegen-maven-plugin/pom.xml
+++ b/maven-plugins/sitegen-maven-plugin/pom.xml
@@ -60,7 +60,6 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-archiver</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
This fixes a regression introduced by #1020.  That PR removed a dependency on the `maven-site-plugin`. As it turns out, the site plugin was bringing some transitive dependencies we needed at runtime (like maven-archiver and plexus-archiver stuff).  So we change maven-archiver to compile scope so it (and plexus archiver) are now present at runtime.

This was discovered when trying to build the Helidon docs and getting exceptions like
```
Caused by: java.lang.ClassNotFoundException: org.codehaus.plexus.archiver.jar.ManifestException
```
