### PR TITLE
Guava upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -885,6 +885,7 @@
                 <version>${version.lib.gson}</version>
             </dependency>
             <dependency>
+                <!-- force upgrade trans dep of lsp4j and maven-core -->
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${version.lib.guava}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
         <version.lib.freemarker>2.3.23</version.lib.freemarker>
         <version.lib.groovy>2.4.16</version.lib.groovy>
         <version.lib.gson>2.8.9</version.lib.gson>
+        <version.lib.guava>32.0.1-jre</version.lib.guava>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
         <version.lib.invoker>3.0.1</version.lib.invoker>
         <version.lib.jackson>2.11.0</version.lib.jackson>
@@ -882,6 +883,11 @@
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${version.lib.gson}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${version.lib.guava}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.shared</groupId>


### PR DESCRIPTION
Force upgrade of guava to 32.0.1-jre

Guava is a transitive dependency of lsp4j and maven-core. 