### PR TITLE
4.x: Upgrade github actions to v4

### DIFF
--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -109,7 +109,7 @@ runs:
         git config --global core.eol lf
     - name: Set up GraalVM
       if: ${{ inputs.native-image == 'true' }}
-      uses: graalvm/setup-graalvm@v1.1.2.1
+      uses: graalvm/setup-graalvm@v1.2.1
       with:
         java-version: ${{ env.JAVA_VERSION }}
         version: ${{ env.GRAALVM_VERSION }}

--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -117,13 +117,13 @@ runs:
         check-for-updates: 'false'
         set-java-home: 'false'
     - name: Set up JDK
-      uses: actions/setup-java@v3.11.0
+      uses: actions/setup-java@v4.1.0
       with:
         distribution: ${{ env.JAVA_DISTRO }}
         java-version: ${{ env.JAVA_VERSION }}
     - name: Cache local Maven repository (read-write)
       if: ${{ inputs.maven-cache == 'read-write' }}
-      uses: actions/cache@v3.3.1
+      uses: actions/cache@v4.0.2
       with:
         path: |
           .m2/repository/**
@@ -134,7 +134,7 @@ runs:
           local-maven-
     - name: Cache local Maven repository (read-only)
       if: ${{ inputs.maven-cache == 'read-only' }}
-      uses: actions/cache/restore@v3.3.1
+      uses: actions/cache/restore@v4.0.2
       with:
         path: |
           .m2/repository/**
@@ -145,7 +145,7 @@ runs:
           local-maven-
     - name: Build cache (read-write)
       if: ${{ inputs.build-cache == 'read-write' }}
-      uses: actions/cache@v3.3.1
+      uses: actions/cache@v4.0.2
       with:
         path: |
           ./**/target/**
@@ -157,7 +157,7 @@ runs:
           build-cache-${{ github.run_id }}-
     - name: Build cache (read-only)
       if: ${{ inputs.build-cache == 'read-only' }}
-      uses: actions/cache/restore@v3.3.1
+      uses: actions/cache/restore@v4.0.2
       with:
         path: |
           ./**/target/**
@@ -192,7 +192,7 @@ runs:
     - name: Archive test results
       # https://github.com/actions/upload-artifact/issues/240
       if: ${{ inputs.archive-test-results == 'true' && runner.os != 'Windows' && always() }}
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@v4
       with:
         if-no-files-found: 'ignore'
         name: test-results
@@ -202,7 +202,7 @@ runs:
           **/target/it/**/*.log
     - name: Archive artifacts
       if: ${{ inputs.artifact-name != '' && inputs.artifact-path != ''  && always() }}
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@v4
       with:
         if-no-files-found: 'ignore'
         name: ${{ inputs.artifact-name }}

--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -56,10 +56,10 @@ inputs:
     description: Path of the files to include in the artifact
     required: false
     default: ''
-  archive-test-results:
-    description: Wether to archive test results (excluded on windows)
+  test-artifact-name:
+    description: Name of the test artifact to create (excluded on windows)
     required: false
-    default: 'false'
+    default: ''
   test-matrix:
     description: |
       A JSON matrix with a "group" dimension, and a "groups" object to resolve Maven modules
@@ -191,11 +191,11 @@ runs:
       shell: bash
     - name: Archive test results
       # https://github.com/actions/upload-artifact/issues/240
-      if: ${{ inputs.archive-test-results == 'true' && runner.os != 'Windows' && always() }}
+      if: ${{ inputs.test-artifact-name != '' && runner.os != 'Windows' && always() }}
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: 'ignore'
-        name: test-results
+        name: ${{ inputs.test-artifact-name }}
         path: |
           **/target/surefire-reports/*.txt
           **/target/failsafe-reports/*.txt

--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -57,7 +57,7 @@ inputs:
     required: false
     default: ''
   test-artifact-name:
-    description: Name of the test artifact to create (excluded on windows)
+    description: Name of the test artifact to create (excluded on windows), if non empty tests are archived
     required: false
     default: ''
   test-matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,11 @@ jobs:
     outputs:
       tag: ${{ steps.create-tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.SERVICE_ACCOUNT_TOKEN }}
       - name: Set up JDK
-        uses: actions/setup-java@v3.11.0
+        uses: actions/setup-java@v4.1.0
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 30
     environment: release
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.create-tag.outputs.tag }}
       - uses: ./.github/actions/common

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           build-cache: read-write
           maven-cache: read-write
-          artifact-name: helidon-cli
+          artifact-name: helidon-cli-dist
           artifact-path: cli/impl/target/helidon-cli.zip
           run: |
             mvn ${MAVEN_ARGS} -T 8 \
@@ -129,6 +129,13 @@ jobs:
               -Pbuild-cache \
               -Dsurefire.reportNameSuffix=${{ matrix.platform }} \
               verify
+  merge-tests:
+    runs-on: ubuntu-20.04
+    needs: test
+    steps:
+      - uses: actions/upload-artifact/merge@v4
+        with:
+          name: test-results
   spotbugs:
     needs: build
     timeout-minutes: 15
@@ -222,3 +229,10 @@ jobs:
               -Dsurefire.reportNameSuffix=native-image-${{ matrix.platform }} \
               -Dtest=CliFunctionalV2Test#*Native* \
               test
+  merge-cli:
+    runs-on: ubuntu-20.04
+    needs: cli
+    steps:
+      - uses: actions/upload-artifact/merge@v4
+        with:
+          name: helidon-cli

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -229,9 +229,7 @@ jobs:
       - uses: actions/upload-artifact/merge@v4
         with:
           name: helidon-cli
-          pattern: |
-            helidon-cli-bin-*
-            helidon-cli-dist
+          pattern: "helidon-cli-{bin-*,dist}"
   test-results:
     runs-on: ubuntu-20.04
     needs: [ tests, cli ]
@@ -239,6 +237,4 @@ jobs:
       - uses: actions/upload-artifact/merge@v4
         with:
           name: test-results
-          path: |
-            tests-*
-            helidon-cli-smoketests-*
+          pattern: "*test*"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -122,7 +122,7 @@ jobs:
       - uses: ./.github/actions/common
         with:
           build-cache: read-only
-          archive-test-results: true
+          test-artifact-name: tests-${{ matrix.group }}-${{ matrix.platform }}
           run: |
             mvn ${MAVEN_ARGS} \
               -pl ${{ matrix.modules }} \
@@ -202,8 +202,8 @@ jobs:
         with:
           build-cache: read-only
           native-image: true
-          archive-test-results: true
-          artifact-name: helidon-cli
+          test-artifact-name: helidon-cli-smoketest-${{ matrix.platform }}
+          artifact-name: helidon-cli-${{ matrix.platform }}
           artifact-path: cli/impl/target/helidon-cli-${{ matrix.platform }}${{ matrix.file-ext }}
           run: |
             # build the executable

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,7 +37,7 @@ env:
     -Djdk.toolchain.version=${JAVA_VERSION}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
 jobs:
@@ -129,13 +129,6 @@ jobs:
               -Pbuild-cache \
               -Dsurefire.reportNameSuffix=${{ matrix.platform }} \
               verify
-  merge-tests:
-    runs-on: ubuntu-20.04
-    needs: tests
-    steps:
-      - uses: actions/upload-artifact/merge@v4
-        with:
-          name: test-results
   spotbugs:
     needs: build
     timeout-minutes: 15
@@ -210,7 +203,7 @@ jobs:
           build-cache: read-only
           native-image: true
           test-artifact-name: helidon-cli-smoketest-${{ matrix.platform }}
-          artifact-name: helidon-cli-${{ matrix.platform }}
+          artifact-name: helidon-cli-bin-${{ matrix.platform }}
           artifact-path: cli/impl/target/helidon-cli-${{ matrix.platform }}${{ matrix.file-ext }}
           run: |
             # build the executable
@@ -229,10 +222,23 @@ jobs:
               -Dsurefire.reportNameSuffix=native-image-${{ matrix.platform }} \
               -Dtest=CliFunctionalV2Test#*Native* \
               test
-  merge-cli:
+  cli-binaries:
     runs-on: ubuntu-20.04
     needs: cli
     steps:
       - uses: actions/upload-artifact/merge@v4
         with:
           name: helidon-cli
+          pattern: |
+            helidon-cli-bin-*
+            helidon-cli-dist
+  test-results:
+    runs-on: ubuntu-20.04
+    needs: [ tests, cli ]
+    steps:
+      - uses: actions/upload-artifact/merge@v4
+        with:
+          name: test-results
+          path: |
+            tests-*
+            helidon-cli-smoketests-*

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -131,7 +131,7 @@ jobs:
               verify
   merge-tests:
     runs-on: ubuntu-20.04
-    needs: test
+    needs: tests
     steps:
       - uses: actions/upload-artifact/merge@v4
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
@@ -78,7 +78,7 @@ jobs:
     outputs:
       test-matrix: ${{ steps.build.outputs.test-matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - id: build
@@ -116,7 +116,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: tests/${{ matrix.group }}-${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
@@ -134,7 +134,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
@@ -150,7 +150,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
@@ -166,7 +166,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
@@ -195,7 +195,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: cli/${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -224,7 +224,7 @@ jobs:
               test
   cli-binaries:
     runs-on: ubuntu-20.04
-    needs: cli
+    needs: [ build, cli ]
     steps:
       - uses: actions/upload-artifact/merge@v4
         with:


### PR DESCRIPTION
Upgrade github actions to v4 because v3 versions are deprecated.