### PR TITLE
Implement JUnitLauncher identity to use with @EnabledIfSystemProperty

### DIFF
--- a/dev-loop/dev-loop/src/test/java/io/helidon/build/devloop/BuildLoopTestIT.java
+++ b/dev-loop/dev-loop/src/test/java/io/helidon/build/devloop/BuildLoopTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,10 +28,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.helidon.build.common.FileChanges.DetectionType;
 import io.helidon.build.common.logging.Log;
 import io.helidon.build.common.test.utils.ConfigurationParameterSource;
+import io.helidon.build.common.test.utils.JUnitLauncher;
 import io.helidon.build.devloop.maven.MavenProjectSupplier;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import static io.helidon.build.common.FileUtils.lastModifiedTime;
@@ -48,9 +50,11 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 /**
- * Unit test for class {@link BuildLoop}.
+ * Tests {@link BuildLoop}.
  */
 @Order(4)
+@EnabledIfSystemProperty(named = JUnitLauncher.IDENTITY_PROP, matches = "true")
+@SuppressWarnings({"SpellCheckingInspection", "ExtractMethodRecommender", "WriteOnlyObject"})
 class BuildLoopTestIT {
 
     private static final String VALID_JAVA_PUBLIC_CLASS_PREFIX = "public class ";

--- a/dev-loop/dev-loop/src/test/java/io/helidon/build/devloop/BuildRootTestIT.java
+++ b/dev-loop/dev-loop/src/test/java/io/helidon/build/devloop/BuildRootTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.helidon.build.common.test.utils.ConfigurationParameterSource;
+import io.helidon.build.common.test.utils.JUnitLauncher;
 
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import static io.helidon.build.common.FileUtils.delete;
@@ -38,9 +40,10 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 /**
- * Unit test for class {@link BuildRoot}.
+ * Tests {@link BuildRoot}.
  */
 @Order(5)
+@EnabledIfSystemProperty(named = JUnitLauncher.IDENTITY_PROP, matches = "true")
 class BuildRootTestIT {
 
     private static BuildRoot sourceDirectory(String basedir) {

--- a/dev-loop/dev-loop/src/test/java/io/helidon/build/devloop/maven/DefaultProjectSupplierTestIT.java
+++ b/dev-loop/dev-loop/src/test/java/io/helidon/build/devloop/maven/DefaultProjectSupplierTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import io.helidon.build.common.test.utils.ConfigurationParameterSource;
+import io.helidon.build.common.test.utils.JUnitLauncher;
 import io.helidon.build.devloop.BuildComponent;
 import io.helidon.build.devloop.BuildExecutor;
 import io.helidon.build.devloop.DirectoryType;
@@ -32,6 +33,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import static io.helidon.build.common.test.utils.TestFiles.pathOf;
@@ -43,10 +45,12 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 /**
- * Unit test for class {@link DefaultProjectSupplier}.
+ * Tests {@link DefaultProjectSupplier}.
  */
 @Order(1)
 @TestMethodOrder(OrderAnnotation.class)
+@EnabledIfSystemProperty(named = JUnitLauncher.IDENTITY_PROP, matches = "true")
+@SuppressWarnings("SpellCheckingInspection")
 class DefaultProjectSupplierTestIT {
 
     @Order(2)

--- a/dev-loop/dev-loop/src/test/java/io/helidon/build/devloop/maven/MavenProjectSupplierTestIT.java
+++ b/dev-loop/dev-loop/src/test/java/io/helidon/build/devloop/maven/MavenProjectSupplierTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,10 @@ import java.util.function.Predicate;
 import io.helidon.build.common.FileChanges.DetectionType;
 import io.helidon.build.common.logging.Log;
 import io.helidon.build.common.test.utils.ConfigurationParameterSource;
+import io.helidon.build.common.test.utils.JUnitLauncher;
 
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import static io.helidon.build.common.FileChanges.DetectionType.FIRST;
@@ -42,9 +44,11 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * Unit test for class {@link MavenProjectSupplier}.
+ * Tests {@link MavenProjectSupplier}.
  */
 @Order(3)
+@EnabledIfSystemProperty(named = JUnitLauncher.IDENTITY_PROP, matches = "true")
+@SuppressWarnings("SpellCheckingInspection")
 class MavenProjectSupplierTestIT {
 
     private static final Predicate<Path> NOT_TEST_LOG = f -> !f.getFileName().toString().equals("test.log");

--- a/linker/src/test/java/io/helidon/build/linker/ApplicationTestIT.java
+++ b/linker/src/test/java/io/helidon/build/linker/ApplicationTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,12 @@ package io.helidon.build.linker;
 import java.nio.file.Path;
 
 import io.helidon.build.common.test.utils.ConfigurationParameterSource;
+import io.helidon.build.common.test.utils.JUnitLauncher;
 import io.helidon.build.linker.util.JavaRuntime;
 
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -33,6 +35,7 @@ import static org.hamcrest.Matchers.notNullValue;
  * Integration test for class {@link Application}.
  */
 @Order(1)
+@EnabledIfSystemProperty(named = JUnitLauncher.IDENTITY_PROP, matches = "true")
 class ApplicationTestIT {
 
     @Tag("mp")

--- a/linker/src/test/java/io/helidon/build/linker/ClassDataSharingTestIT.java
+++ b/linker/src/test/java/io/helidon/build/linker/ClassDataSharingTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,14 @@ import java.util.List;
 
 import io.helidon.build.common.logging.LogLevel;
 import io.helidon.build.common.test.utils.ConfigurationParameterSource;
+import io.helidon.build.common.test.utils.JUnitLauncher;
 import io.helidon.build.common.test.utils.TestLogLevel;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import static io.helidon.build.common.FileUtils.javaHome;
@@ -41,6 +43,7 @@ import static org.hamcrest.Matchers.nullValue;
  * Integration test for class {@link ClassDataSharing}.
  */
 @Order(2)
+@EnabledIfSystemProperty(named = JUnitLauncher.IDENTITY_PROP, matches = "true")
 class ClassDataSharingTestIT {
 
     private static final Path JAVA_HOME = Path.of(javaHome());

--- a/linker/src/test/java/io/helidon/build/linker/JarTestIT.java
+++ b/linker/src/test/java/io/helidon/build/linker/JarTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,12 @@ package io.helidon.build.linker;
 import java.nio.file.Path;
 
 import io.helidon.build.common.test.utils.ConfigurationParameterSource;
+import io.helidon.build.common.test.utils.JUnitLauncher;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -32,6 +34,7 @@ import static org.hamcrest.Matchers.notNullValue;
  * Integration test for class {@link Jar}.
  */
 @Order(3)
+@EnabledIfSystemProperty(named = JUnitLauncher.IDENTITY_PROP, matches = "true")
 class JarTestIT {
 
     @Tag("multi-release")

--- a/linker/src/test/java/io/helidon/build/linker/LinkerTestIT.java
+++ b/linker/src/test/java/io/helidon/build/linker/LinkerTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.util.Set;
 
 import io.helidon.build.common.test.utils.ConfigurationParameterSource;
+import io.helidon.build.common.test.utils.JUnitLauncher;
 import io.helidon.build.linker.util.Constants;
 import io.helidon.build.linker.util.JavaRuntime;
 
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import static io.helidon.build.common.FileUtils.listFiles;
@@ -47,6 +49,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @Order(4)
 @TestMethodOrder(OrderAnnotation.class)
+@EnabledIfSystemProperty(named = JUnitLauncher.IDENTITY_PROP, matches = "true")
 class LinkerTestIT {
 
     @Tag("se")

--- a/maven-plugins/build-cache-maven-plugin/src/test/java/io/helidon/build/maven/cache/ProjectsTestIT.java
+++ b/maven-plugins/build-cache-maven-plugin/src/test/java/io/helidon/build/maven/cache/ProjectsTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@ import java.util.List;
 
 import io.helidon.build.common.test.utils.BuildLog;
 import io.helidon.build.common.test.utils.ConfigurationParameterSource;
+import io.helidon.build.common.test.utils.JUnitLauncher;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import static io.helidon.build.common.test.utils.BuildLog.assertDiffs;
@@ -31,7 +33,8 @@ import static org.hamcrest.Matchers.is;
 /**
  * Integration test that verifies the projects under {@code src/it/projects}.
  */
-final class ProjectsTestIT {
+@EnabledIfSystemProperty(named = JUnitLauncher.IDENTITY_PROP, matches = "true")
+class ProjectsTestIT {
 
     @ParameterizedTest
     @ConfigurationParameterSource("basedir")

--- a/maven-plugins/enforcer-maven-plugin/src/test/java/io/helidon/build/maven/enforcer/GitIgnoreTestIT.java
+++ b/maven-plugins/enforcer-maven-plugin/src/test/java/io/helidon/build/maven/enforcer/GitIgnoreTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,13 +22,20 @@ import java.util.List;
 
 import io.helidon.build.common.test.utils.BuildLog;
 import io.helidon.build.common.test.utils.ConfigurationParameterSource;
+import io.helidon.build.common.test.utils.JUnitLauncher;
+
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import static io.helidon.build.common.test.utils.BuildLog.assertDiffs;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class GitIgnoreTestIT {
+/**
+ * Integration test that verifies the projects under {@code src/it/projects}.
+ */
+@EnabledIfSystemProperty(named = JUnitLauncher.IDENTITY_PROP, matches = "true")
+class GitIgnoreTestIT {
 
     @ParameterizedTest
     @ConfigurationParameterSource("basedir")

--- a/maven-plugins/helidon-archetype-maven-plugin/src/test/java/io/helidon/build/maven/archetype/ProjectsTestIT.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/test/java/io/helidon/build/maven/archetype/ProjectsTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,9 @@ import java.util.stream.Collectors;
 
 import io.helidon.build.common.test.utils.BuildLog;
 import io.helidon.build.common.test.utils.ConfigurationParameterSource;
+import io.helidon.build.common.test.utils.JUnitLauncher;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import static io.helidon.build.common.test.utils.BuildLog.assertDiffs;
@@ -35,7 +37,8 @@ import static org.hamcrest.Matchers.is;
 /**
  * Integration test that verifies the projects under {@code src/it/projects}.
  */
-final class ProjectsTestIT {
+@EnabledIfSystemProperty(named = JUnitLauncher.IDENTITY_PROP, matches = "true")
+class ProjectsTestIT {
 
     private static final String TEST_PKG = "io.helidon.build.maven.archetype.tests";
     private static final String TEST_PKG_DIR = TEST_PKG.replaceAll("\\.", "/");

--- a/maven-plugins/helidon-maven-plugin/src/test/java/io/helidon/build/maven/ProjectsTestIT.java
+++ b/maven-plugins/helidon-maven-plugin/src/test/java/io/helidon/build/maven/ProjectsTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,9 @@ import java.util.List;
 
 import io.helidon.build.common.test.utils.BuildLog;
 import io.helidon.build.common.test.utils.ConfigurationParameterSource;
+import io.helidon.build.common.test.utils.JUnitLauncher;
+
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import static io.helidon.build.common.test.utils.BuildLog.assertDiffs;
@@ -31,7 +34,8 @@ import static io.helidon.build.common.test.utils.BuildLog.assertDiffs;
 /**
  * Integration test that verifies the projects under {@code src/it/projects}.
  */
-public class ProjectsTestIT {
+@EnabledIfSystemProperty(named = JUnitLauncher.IDENTITY_PROP, matches = "true")
+class ProjectsTestIT {
 
     @ParameterizedTest
     @ConfigurationParameterSource("basedir")

--- a/maven-plugins/javadoc-maven-plugin/src/test/java/io/helidon/build/javadoc/ProjectsTestIT.java
+++ b/maven-plugins/javadoc-maven-plugin/src/test/java/io/helidon/build/javadoc/ProjectsTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,9 @@ package io.helidon.build.javadoc;
 import java.nio.file.Path;
 
 import io.helidon.build.common.test.utils.ConfigurationParameterSource;
+import io.helidon.build.common.test.utils.JUnitLauncher;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import static io.helidon.build.common.test.utils.FileMatchers.fileExists;
@@ -27,7 +29,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Integration test that verifies the projects under {@code src/it/projects}.
  */
-final class ProjectsTestIT {
+@EnabledIfSystemProperty(named = JUnitLauncher.IDENTITY_PROP, matches = "true")
+class ProjectsTestIT {
 
     @ParameterizedTest
     @ConfigurationParameterSource("basedir")

--- a/maven-plugins/stager-maven-plugin/src/test/java/io/helidon/build/maven/stager/ProjectsTestIT.java
+++ b/maven-plugins/stager-maven-plugin/src/test/java/io/helidon/build/maven/stager/ProjectsTestIT.java
@@ -22,7 +22,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import io.helidon.build.common.test.utils.ConfigurationParameterSource;
+import io.helidon.build.common.test.utils.JUnitLauncher;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import static io.helidon.build.common.FileUtils.newZipFileSystem;
@@ -33,7 +35,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 
-public class ProjectsTestIT {
+/**
+ * Integration test that verifies the projects under {@code src/it/projects}.
+ */
+@EnabledIfSystemProperty(named = JUnitLauncher.IDENTITY_PROP, matches = "true")
+class ProjectsTestIT {
 
     @ParameterizedTest
     @ConfigurationParameterSource("basedir")


### PR DESCRIPTION
Implement JUnitLauncher identity to use with @EnabledIfSystemProperty
 - These tests can only be run via the postbuild.groovy hook of the maven-invoker-plugin.
 - The annotation ensures that when running with any other launcher, the test is skipped (E.g. IDE)
