### PR TITLE
Helidon Archetype Maven Plugin - Update integration-test mojo

### DIFF
--- a/maven-plugins/helidon-archetype-maven-plugin/README.md
+++ b/maven-plugins/helidon-archetype-maven-plugin/README.md
@@ -25,21 +25,21 @@ This goal binds to the `package` phase by default.
 ### General usage
 
 The plugin includes a custom packaging `helidon-archetype`. You need to declare the plugin as an extension to enable
- the use of the custom packaging.
+the use of the custom packaging.
 
 ```xml
 <project>
-    <!-- ... -->
-    <packaging>helidon-archetype</packaging>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.helidon.build-tools</groupId>
-                <artifactId>helidon-archetype-maven-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
+ <!-- ... -->
+ <packaging>helidon-archetype</packaging>
+ <build>
+  <plugins>
+   <plugin>
+    <groupId>io.helidon.build-tools</groupId>
+    <artifactId>helidon-archetype-maven-plugin</artifactId>
+    <extensions>true</extensions>
+   </plugin>
+  </plugins>
+ </build>
 </project>
 ```
 
@@ -51,7 +51,8 @@ Maven goal to test Helidon archetypes.
 |--------------------------|---------|-------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
 | invokerEnvVars           | Map     | `{}`                                            | Invoker environment variables                                                                                              |
 | permutation              | String  | `null`                                          | Indices (comma separated) of the permutations to process                                                                   |
-| permutationStartIndex    | Integer | `1`                                             | Permutation start index (resume-from)                                                                                      |
+| permutationStartIndex    | Integer | `1`                                             | Permutation start index                                                                                                    |
+| permutationEndIndex      | Integer | `-1`                                            | Permutation end index                                                                                                      |
 | permutationsOnly         | boolean | `false`                                         | Whether to only generate input permutations                                                                                |
 | generatePermutations     | boolean | `true`                                          | Whether to auto-compute input permutations                                                                                 |
 | permutationFilters       | List    | `[]`                                            | Permutation filters to filter the computed permutations.                                                                   |
@@ -61,6 +62,7 @@ Maven goal to test Helidon archetypes.
 | externalDefaults         | boolean | `false`                                         | External defaults to use when generating archetypes                                                                        |
 | externalValues           | boolean | `false`                                         | External values to use when generating archetypes                                                                          |
 | testGoal                 | String  | `package`                                       | The goal to use when building archetypes.                                                                                  |
+| testProfiles             | List    | `[]`                                            | The profiles to use when building archetypes.                                                                              |
 | mavenArchetypeCompatible | boolean | `60`                                            | Indicate if the project should be generated with the maven-archetype-plugin or with the Helidon archetype engine directly. |
 | debug                    | boolean | `false`                                         | Whether to show debug statements in the build output                                                                       |
 | showVersion              | boolean | `false`                                         | flag to show the maven version used.                                                                                       |

--- a/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/PluginContainerManager.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/PluginContainerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,8 @@
  */
 package io.helidon.build.maven.archetype;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 
@@ -33,6 +31,7 @@ import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.PlexusContainerException;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.configuration.PlexusConfigurationException;
@@ -74,15 +73,11 @@ public class PluginContainerManager {
             containerConfiguration.setClassPathScanning(PlexusConstants.SCANNING_INDEX);
             containerConfiguration.setRealm(classRealm);
             PlexusContainer container = new DefaultPlexusContainer(containerConfiguration);
-            Deque<ClassRealm> stack = new ArrayDeque<>();
-            stack.push(classRealm);
-            while (!stack.isEmpty()) {
-                ClassRealm realm = stack.pop();
-                container.discoverComponents(realm);
-                realm.getImportRealms().forEach(stack::push);
-            }
+            container.discoverComponents(classRealm);
+            container.discoverComponents(classRealm.getWorld().getRealm("maven.api"));
+            container.discoverComponents(classRealm.getWorld().getRealm("plexus.core"));
             return container;
-        } catch (PlexusContainerException | PlexusConfigurationException ex) {
+        } catch (PlexusContainerException | PlexusConfigurationException | NoSuchRealmException ex) {
             throw new RuntimeException(ex);
         }
     }


### PR DESCRIPTION
Update helidon-archetype:integration-test

- Implement permutationEndIndex and testProfiles
- Fix projectName when using  -Darchetype.test.generatePermutations=false
- Fix integration-test mojo to use user specified local repository
- Fix plexus hacks in integration-test mojo
