### PR TITLE
Inline spotbugs lifecycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -969,8 +969,10 @@
                         <executions>
                             <execution>
                                 <goals>
-                                    <goal>check</goal>
+                                    <goal>spotbugs</goal>
+                                    <goal>verify</goal>
                                 </goals>
+                                <phase>verify</phase>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
- Use spotbugs:spotbugs + spotbugs:verify instead of spotbugs:check
- spotbugs:check forks lifecycle, this avoids lifecycle duplication