### PR TITLE
Fix NPE ProjectExecutionManager.resolvePhase

### DIFF
--- a/maven-plugins/build-cache-maven-extension/src/main/java/io/helidon/build/maven/cache/ProjectExecutionManager.java
+++ b/maven-plugins/build-cache-maven-extension/src/main/java/io/helidon/build/maven/cache/ProjectExecutionManager.java
@@ -185,6 +185,9 @@ public class ProjectExecutionManager {
         try {
             lock.lock();
             Lifecycle lifecycle = defaultLifecycles.get(phase);
+            if (lifecycle == null) {
+                return List.of();
+            }
             LifecycleMappingDelegate lifecycleDelegate = null;
             if (Arrays.binarySearch(DefaultLifecycles.STANDARD_LIFECYCLES, lifecycle.getId()) < 0) {
                 lifecycleDelegate = lifecycleDelegates.get(lifecycle.getId());


### PR DESCRIPTION
Fix NPE ProjectExecutionManager.resolvePhase

- defaultLifecycles.get(phase) can return null as phase is the value provided by users on the command line. E.g. direct mojo execution.