### PR TITLE
Fix project state applying of source roots

### DIFF
--- a/maven-plugins/build-cache-maven-extension/src/it/projects/test3/.mvn/cache-config.xml
+++ b/maven-plugins/build-cache-maven-extension/src/it/projects/test3/.mvn/cache-config.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<cacheConfig>
+    <enabled>true</enabled>
+    <lifecycleConfig>
+        <project glob="**">
+            <projectFilesExcludes>
+                <exclude>*.log</exclude>
+                <exclude>interpolated-pom.xml</exclude>
+            </projectFilesExcludes>
+        </project>
+    </lifecycleConfig>
+</cacheConfig>

--- a/maven-plugins/build-cache-maven-extension/src/it/projects/test3/.mvn/extensions.xml
+++ b/maven-plugins/build-cache-maven-extension/src/it/projects/test3/.mvn/extensions.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.1.0.xsd">
+    <extension>
+        <groupId>io.helidon.build-tools</groupId>
+        <artifactId>helidon-build-cache-maven-extension</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/maven-plugins/build-cache-maven-extension/src/it/projects/test3/invoker.properties
+++ b/maven-plugins/build-cache-maven-extension/src/it/projects/test3/invoker.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.name = Initial build
+invoker.description = Generates build cache for subsequent runs
+invoker.goals = clean install -DskipTests
+
+invoker.name.2 = Cached build #1
+invoker.description.2 = Re-uses the build cache
+invoker.goals.2 = package -DskipTests -Pjavadoc
+

--- a/maven-plugins/build-cache-maven-extension/src/it/projects/test3/pom.xml
+++ b/maven-plugins/build-cache-maven-extension/src/it/projects/test3/pom.xml
@@ -1,0 +1,122 @@
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.helidon.build-tools.cache.tests</groupId>
+    <artifactId>test3</artifactId>
+    <version>@project.version@</version>
+    <name>Test State 3</name>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <surefire.coverage.argLine />
+        <surefire.argLine>-Xmx1024m -Dfile.encoding=UTF-8</surefire.argLine>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/generated/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>2.7</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.13.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.6.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.6.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.12.4</version>
+                    <configuration>
+                        <!-- this is an example of a configuration -->
+                        <argLine>${surefire.argLine} ${surefire.coverage.argLine}</argLine>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>javadoc</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/maven-plugins/build-cache-maven-extension/src/it/projects/test3/postbuild.groovy
+++ b/maven-plugins/build-cache-maven-extension/src/it/projects/test3/postbuild.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.helidon.build.common.test.utils.JUnitLauncher
+import io.helidon.build.maven.cache.ProjectsTestIT
+
+JUnitLauncher.builder()
+        .select(ProjectsTestIT.class, "test3", String.class)
+        .parameter("basedir", basedir.getAbsolutePath())
+        .reportsDir(basedir)
+        .outputFile(new File(basedir, "test.log"))
+        .suiteId("build-cache-it-test3")
+        .suiteDisplayName("Build Cache Integration Test 3")
+        .build()
+        .launch()

--- a/maven-plugins/build-cache-maven-extension/src/it/projects/test3/src/generated/java/io/helidon/build/cache/test/Greeting.java
+++ b/maven-plugins/build-cache-maven-extension/src/it/projects/test3/src/generated/java/io/helidon/build/cache/test/Greeting.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.build.cache.test;
+
+/**
+ * Greeting.
+ */
+public class Greeting {
+
+    /**
+     * Create a greeting.
+     *
+     * @param name name
+     * @return greeting
+     */
+    public String greet(String name) {
+        return "Hello " + name;
+    }
+}

--- a/maven-plugins/build-cache-maven-extension/src/it/projects/test3/src/generated/java/io/helidon/build/cache/test/package-info.java
+++ b/maven-plugins/build-cache-maven-extension/src/it/projects/test3/src/generated/java/io/helidon/build/cache/test/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Helidon Build Cache Test.
+ */
+package io.helidon.build.cache.test;

--- a/maven-plugins/build-cache-maven-extension/src/main/java/io/helidon/build/maven/cache/ProjectState.java
+++ b/maven-plugins/build-cache-maven-extension/src/main/java/io/helidon/build/maven/cache/ProjectState.java
@@ -39,6 +39,8 @@ import org.apache.maven.model.Model;
 import org.apache.maven.project.DefaultMavenProjectHelper;
 import org.apache.maven.project.MavenProject;
 
+import static java.util.function.Predicate.not;
+
 /**
  * Project state.
  */
@@ -333,13 +335,13 @@ final class ProjectState {
                 .stream()
                 .map(projectDir::resolve)
                 .map(Object::toString)
-                .filter(project.getCompileSourceRoots()::contains)
+                .filter(not(project.getCompileSourceRoots()::contains))
                 .forEach(project::addCompileSourceRoot);
         testCompileSourceRoots
                 .stream()
                 .map(projectDir::resolve)
                 .map(Object::toString)
-                .filter(project.getTestCompileSourceRoots()::contains)
+                .filter(not(project.getTestCompileSourceRoots()::contains))
                 .forEach(project::addTestCompileSourceRoot);
         attachedArtifacts
                 .stream()

--- a/maven-plugins/build-cache-maven-extension/src/test/java/io/helidon/build/maven/cache/ProjectsTestIT.java
+++ b/maven-plugins/build-cache-maven-extension/src/test/java/io/helidon/build/maven/cache/ProjectsTestIT.java
@@ -17,6 +17,7 @@ package io.helidon.build.maven.cache;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import io.helidon.build.common.test.utils.BuildLog;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import static io.helidon.build.common.test.utils.BuildLog.assertDiffs;
+import static io.helidon.build.common.test.utils.FileMatchers.fileExists;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -60,5 +62,13 @@ class ProjectsTestIT {
 
         int index2 = buildLog.indexOf("Downstream state(s) not available, state is ignored", index1);
         assertThat(index2 > 0, is(true));
+    }
+
+    @ParameterizedTest
+    @ConfigurationParameterSource("basedir")
+    void test3(String basedir) {
+        Path apidocs = Path.of(basedir).resolve("target/apidocs");
+        Path greetings = apidocs.resolve("io/helidon/build/cache/test/Greeting.html");
+        assertThat(greetings, fileExists());
     }
 }


### PR DESCRIPTION
- The filtering to avoid duplicate needs to exclude existing source roots.
- Add test that illustrates the use-case with a generated source root and javadoc