### PR TITLE
Fix ArtifactHandler in build-cache-maven-extension

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ env:
     -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
     -Dmaven.wagon.http.retryHandler.count=3
     -Djdk.toolchain.version=${JAVA_VERSION}
+    -Dcache.enabled=true
 
 concurrency:
   group: release-${{ github.workflow }}-${{ github.ref }}

--- a/common/xml/src/main/java/io/helidon/build/common/xml/XMLElement.java
+++ b/common/xml/src/main/java/io/helidon/build/common/xml/XMLElement.java
@@ -96,6 +96,23 @@ public interface XMLElement {
     Optional<XMLElement> child(String name);
 
     /**
+     * Get a child by path.
+     *
+     * @param path path
+     * @return optional
+     */
+    default Optional<XMLElement> childAt(String... path) {
+        if (path.length == 0) {
+            return Optional.empty();
+        }
+        Stream<XMLElement> stream = Stream.of(this);
+        for (String p : path) {
+            stream = stream.flatMap(e -> e.children(p).stream());
+        }
+        return stream.findFirst();
+    }
+
+    /**
      * Get the attributes.
      *
      * @return attributes, never {@code null}

--- a/maven-plugins/build-cache-maven-extension/src/it/projects/test3/invoker.properties
+++ b/maven-plugins/build-cache-maven-extension/src/it/projects/test3/invoker.properties
@@ -22,3 +22,6 @@ invoker.name.2 = Cached build #1
 invoker.description.2 = Re-uses the build cache
 invoker.goals.2 = package -DskipTests -Pjavadoc
 
+invoker.name.3 = Cached build #2
+invoker.description.3 = Tests resumed deploy
+invoker.goals.3 = deploy -DaltDeploymentRepository=":::file://${maven.multiModuleProjectDirectory}/staging"

--- a/maven-plugins/build-cache-maven-extension/src/it/projects/test3/pom.xml
+++ b/maven-plugins/build-cache-maven-extension/src/it/projects/test3/pom.xml
@@ -81,6 +81,11 @@
                     <version>3.6.2</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.1.2</version>
+                </plugin>
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>3.6.0</version>

--- a/maven-plugins/build-cache-maven-extension/src/main/java/io/helidon/build/maven/cache/CacheConfig.java
+++ b/maven-plugins/build-cache-maven-extension/src/main/java/io/helidon/build/maven/cache/CacheConfig.java
@@ -353,7 +353,7 @@ public final class CacheConfig {
         String enabledValue = stringProperty(sysProps, userProps, "cache.enabled");
         boolean enabled = parseBoolean(enabledValue, false);
         String recordValue = stringProperty(sysProps, userProps, "cache.record");
-        boolean record = parseBoolean(enabledValue, true);
+        boolean record = parseBoolean(recordValue, true);
         if (xmlElt != null) {
             if (enabledValue == null) {
                 enabled = booleanElement(xmlElt, "enabled", false);

--- a/maven-plugins/build-cache-maven-extension/src/main/java/io/helidon/build/maven/cache/ProjectState.java
+++ b/maven-plugins/build-cache-maven-extension/src/main/java/io/helidon/build/maven/cache/ProjectState.java
@@ -170,7 +170,7 @@ final class ProjectState {
         for (XMLElement elt : rootElt.childrenAt("properties", "property")) {
             String name = elt.attribute("name", null);
             String value = elt.attribute("value", null);
-            if (name != null && !name.isEmpty() && value != null) {
+            if (Strings.isValid(name) && value != null) {
                 properties.setProperty(name, value);
             }
         }
@@ -293,6 +293,7 @@ final class ProjectState {
         Map<String, String> attributes = elt.attributes();
         return new ArtifactEntry(
                 attributes.get("file"),
+                attributes.get("type"),
                 attributes.get("extension"),
                 attributes.get("classifier"),
                 attributes.get("language"),
@@ -302,16 +303,14 @@ final class ProjectState {
 
     private static void writeArtifact(XMLWriter writer, ArtifactEntry artifact) {
         writer.startElement("artifact").attribute("file", artifact.file());
-        String extension = artifact.extension();
-        if (extension != null && !extension.isEmpty()) {
-            writer.attribute("extension", extension);
-        }
+        writer.attribute("type", artifact.type());
+        writer.attribute("extension", artifact.extension());
         String classifier = artifact.classifier();
-        if (classifier != null && !classifier.isEmpty()) {
+        if (Strings.isValid(classifier)) {
             writer.attribute("classifier", classifier);
         }
         String language = artifact.language();
-        if (language != null && !language.isEmpty()) {
+        if (Strings.isValid(language)) {
             writer.attribute("language", language);
         }
         writer.attribute("includesDependencies", artifact.includesDependencies());

--- a/maven-plugins/build-cache-maven-extension/src/main/java/io/helidon/build/maven/cache/ProjectStateManager.java
+++ b/maven-plugins/build-cache-maven-extension/src/main/java/io/helidon/build/maven/cache/ProjectStateManager.java
@@ -81,6 +81,9 @@ public class ProjectStateManager {
     }
 
     private Map<MavenProject, ProjectStateStatus> initStates() {
+        if (session.getGoals().contains("clean")) {
+            return Map.of();
+        }
         ProjectDependencyGraph pdg = session.getProjectDependencyGraph();
         Map<MavenProject, ProjectStateStatus> statusMap = new HashMap<>();
         Deque<MavenProject> stack = new ArrayDeque<>(session.getProjects());

--- a/maven-plugins/build-cache-maven-extension/src/test/java/io/helidon/build/maven/cache/ArtifactEntryTest.java
+++ b/maven-plugins/build-cache-maven-extension/src/test/java/io/helidon/build/maven/cache/ArtifactEntryTest.java
@@ -38,7 +38,7 @@ class ArtifactEntryTest {
     void testToArtifact() {
         MavenProject project = mockMavenProject();
 
-        Artifact artifact = new ArtifactEntry("foo.zip","zip", null, "bar", false,  true).toArtifact(project);
+        Artifact artifact = new ArtifactEntry("foo.zip", "zip", "zip", null, "bar", false,  true).toArtifact(project);
         assertThat(artifact.getGroupId(), is("com.acme"));
         assertThat(artifact.getArtifactId(), is("foo"));
         assertThat(artifact.getVersion(), is("1.0"));
@@ -53,7 +53,7 @@ class ArtifactEntryTest {
         assertThat(artifactHandler.isIncludesDependencies(), is(false));
         assertThat(artifactHandler.isAddedToClasspath(), is(true));
 
-        artifact = new ArtifactEntry("foo.zip", "zip", "alice", "bar", true, false).toArtifact(project);
+        artifact = new ArtifactEntry("foo.zip", "zip", "zip", "alice", "bar", true, false).toArtifact(project);
         assertThat(artifact.getGroupId(), is("com.acme"));
         assertThat(artifact.getArtifactId(), is("foo"));
         assertThat(artifact.getVersion(), is("1.0"));

--- a/maven-plugins/build-cache-maven-extension/src/test/java/io/helidon/build/maven/cache/ProjectStateTest.java
+++ b/maven-plugins/build-cache-maven-extension/src/test/java/io/helidon/build/maven/cache/ProjectStateTest.java
@@ -42,8 +42,8 @@ class ProjectStateTest {
     @Test
     void testSave() throws IOException {
         ProjectState projectState = new ProjectState(Maps.toProperties(Map.of("prop1", "value1")),
-                new ArtifactEntry("artifact.jar", "jar", null, "java", false, true),
-                List.of(new ArtifactEntry("artifact-javadoc.jar", "jar", "javadoc", "java", false, false)),
+                new ArtifactEntry("artifact.jar", "jar", "jar", null, "java", false, true),
+                List.of(new ArtifactEntry("artifact-javadoc.jar", "javadoc", "jar", "javadoc", "java", false, false)),
                 List.of("src/main/java"),
                 List.of("src/test/java"),
                 new ProjectFiles(7, 1717820328080L, null, Map.of()),
@@ -80,9 +80,9 @@ class ProjectStateTest {
         assertThat(Maps.fromProperties(projectState.properties()), is(Map.of("prop1", "value1")));
 
         assertThat(projectState.artifact(),
-                is(new ArtifactEntry("artifact.jar", "jar", null, "java", false, true)));
+                is(new ArtifactEntry("artifact.jar", "jar", "jar", null, "java", false, true)));
         assertThat(projectState.attachedArtifacts(),
-                is(List.of(new ArtifactEntry("artifact-javadoc.jar", "jar", "javadoc", "java", false, false))));
+                is(List.of(new ArtifactEntry("artifact-javadoc.jar", "javadoc", "jar", "javadoc", "java", false, false))));
 
         assertThat(projectState.compileSourceRoots(), is(List.of("src/main/java")));
         assertThat(projectState.testCompileSourceRoots(), is(List.of("src/test/java")));

--- a/maven-plugins/build-cache-maven-extension/src/test/resources/state.xml
+++ b/maven-plugins/build-cache-maven-extension/src/test/resources/state.xml
@@ -20,9 +20,9 @@
     <properties>
         <property name="prop1" value="value1"/>
     </properties>
-    <artifact file="artifact.jar" extension="jar" language="java" includesDependencies="false" addedToClasspath="true"/>
+    <artifact file="artifact.jar" type="jar" extension="jar" language="java" includesDependencies="false" addedToClasspath="true"/>
     <attached-artifacts>
-        <artifact file="artifact-javadoc.jar" extension="jar" classifier="javadoc" language="java" includesDependencies="false" addedToClasspath="false"/>
+        <artifact file="artifact-javadoc.jar" type="javadoc" extension="jar" classifier="javadoc" language="java" includesDependencies="false" addedToClasspath="false"/>
     </attached-artifacts>
     <compile-source-roots>
         <path>src/main/java</path>

--- a/maven-plugins/javadoc-maven-plugin/src/main/java/io/helidon/build/javadoc/JavadocMojo.java
+++ b/maven-plugins/javadoc-maven-plugin/src/main/java/io/helidon/build/javadoc/JavadocMojo.java
@@ -465,8 +465,6 @@ public class JavadocMojo extends AbstractMojo {
         dependencyFilter = MavenFilters.artifactFilter(dependencyIncludes, dependencyExcludes);
         pomFilter = MavenFilters.pomFilter(pomIncludes, pomExcludes);
         sourceFilter = MavenFilters.pathFilter(sourceIncludes, sourceExcludes, projectRoot.toPath());
-        getLog().warn("fileExcludes = " + fileExcludes);
-        getLog().warn("fileIncludes = " + fileIncludes);
         filenameFilter = MavenFilters.stringFilter(fileIncludes, fileExcludes);
         pomIdentityFilter = MavenFilters.dirFilter(pomScanningIdentity);
         pomScanningFilter = MavenFilters.pathFilter(pomScanningIncludes, pomScanningExcludes, projectRoot.toPath());

--- a/maven-plugins/javadoc-maven-plugin/src/test/java/io/helidon/build/javadoc/JavaParserPackageTest.java
+++ b/maven-plugins/javadoc-maven-plugin/src/test/java/io/helidon/build/javadoc/JavaParserPackageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,7 +123,7 @@ class JavaParserPackageTest {
     }
 
     @Test
-    void testUnamedClassWithImports() {
+    void testUnnamedClassWithImports() {
         String src = """
                 import com.acme1;
                 public enum Acme1 {


### PR DESCRIPTION
Fix ArtifactHandler in build-cache-maven-extension.

- Properly handle artifact type and artifact extension to correctly restore/load project state.
- Fix `cache.record` property
- Update unit tests
- Update integration test