### PR TITLE
Make build-cache-maven-extension IT tests version insensitive

### DIFF
--- a/maven-plugins/build-cache-maven-extension/src/it/projects/test1/pom.xml
+++ b/maven-plugins/build-cache-maven-extension/src/it/projects/test1/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.helidon.build-tools.cache.tests</groupId>
     <artifactId>test1</artifactId>
-    <version>@project.version@</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>Test State 1</name>
 
     <properties>

--- a/maven-plugins/build-cache-maven-extension/src/it/projects/test2/module1/pom.xml
+++ b/maven-plugins/build-cache-maven-extension/src/it/projects/test2/module1/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.build-tools.cache.tests</groupId>
         <artifactId>test2-parent</artifactId>
-        <version>@project.version@</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>test2-module1</artifactId>
     <name>Test State 2 Module 1</name>

--- a/maven-plugins/build-cache-maven-extension/src/it/projects/test2/module2/pom.xml
+++ b/maven-plugins/build-cache-maven-extension/src/it/projects/test2/module2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.build-tools.cache.tests</groupId>
         <artifactId>test2-parent</artifactId>
-        <version>@project.version@</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>test2-module2</artifactId>
     <name>Test State 2 Module 2</name>

--- a/maven-plugins/build-cache-maven-extension/src/it/projects/test2/pom.xml
+++ b/maven-plugins/build-cache-maven-extension/src/it/projects/test2/pom.xml
@@ -22,7 +22,7 @@
     <groupId>io.helidon.build-tools.cache.tests</groupId>
     <artifactId>test2-parent</artifactId>
     <packaging>pom</packaging>
-    <version>@project.version@</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>Test State Parent</name>
 
     <properties>

--- a/maven-plugins/build-cache-maven-extension/src/it/projects/test3/pom.xml
+++ b/maven-plugins/build-cache-maven-extension/src/it/projects/test3/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.helidon.build-tools.cache.tests</groupId>
     <artifactId>test3</artifactId>
-    <version>@project.version@</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>Test State 3</name>
 
     <properties>

--- a/maven-plugins/build-cache-maven-extension/src/test/java/io/helidon/build/maven/cache/ProjectsTestIT.java
+++ b/maven-plugins/build-cache-maven-extension/src/test/java/io/helidon/build/maven/cache/ProjectsTestIT.java
@@ -77,7 +77,7 @@ class ProjectsTestIT {
         assertThat(greetings, fileExists());
 
         Path stagingDir = basepath.resolve("staging");
-        Path artifactDir = stagingDir.resolve("io/helidon/build-tools/cache/tests/test3/4.0.0-SNAPSHOT");
+        Path artifactDir = stagingDir.resolve("io/helidon/build-tools/cache/tests/test3/1.0.0-SNAPSHOT");
 
         Path mavenMetadataFile = artifactDir.resolve("maven-metadata.xml");
         assertThat(mavenMetadataFile, fileExists());
@@ -87,7 +87,7 @@ class ProjectsTestIT {
                 .map(XMLElement::value)
                 .orElseThrow(() -> new IllegalStateException("Unable to get timestamp"));
 
-        String version = "4.0.0-" + timestamp + "-1";
+        String version = "1.0.0-" + timestamp + "-1";
 
         List<String> files;
         try (Stream<Path> dirStream = Files.list(artifactDir)) {


### PR DESCRIPTION
Update IT tests in build-cache-maven-extension to be version insensitive.

New tests added in #1061 do test deploy layout which depends on the project version.
However the project used in the test poms was the same as the build-tools version, making the test fail during release.

The fix is to use a separate version as there is no reason to use the actual build-tools version.