### PR TITLE
Maven Build Cache Extension: add support for state file suffix

### DIFF
--- a/maven-plugins/build-cache-maven-extension/README.md
+++ b/maven-plugins/build-cache-maven-extension/README.md
@@ -80,6 +80,23 @@ The configuration resides in `.mvn/cache-config.xml`.
         Can be overridden with -Dcache.enabled=true
      -->
     <enabled>false</enabled>
+    <!--
+        Enable state recording (target/state.xml).
+        Can be overridden with -Dcache.record=false
+    -->
+    <record>true</record>
+    <!--
+        Load additional state files (target/state-{suffix}.xml).
+        Can be overridden with -Dcache.loadSuffixes=foo,bar
+    -->
+    <loadSuffixes>
+        <suffix>foo</suffix>
+    </loadSuffixes>
+    <!--
+        Add a suffix to the state file name used for recording (target/state-{suffix}.xml).
+        Can be overridden with -Dcache.recordSuffix=bar
+    -->
+    <recordSuffix>foo</recordSuffix>
     <!-- Per project configuration -->
     <lifecycleConfig>
         <!-- Indicate if the project files checksum should be computed -->
@@ -156,12 +173,14 @@ The configuration resides in `.mvn/cache-config.xml`.
 
 ### Properties
 
-| Property      | Type    | Default<br/>Value | Description                              |
-|---------------|---------|-------------------|------------------------------------------|
-| cache.enabled | Boolean | `false`           | Enables the extension                    |
-| cache.record  | Boolean | `false`           | Update the recorded cache state          |
-| reactorRule   | String  | `null`            | The reactor rule to use                  |
-| moduleSet     | String  | `null`            | The moduleset in the reactor rule to use |
+| Property           | Type    | Default<br/>Value | Description                                    |
+|--------------------|---------|-------------------|------------------------------------------------|
+| cache.enabled      | Boolean | `false`           | Enables the extension                          |
+| cache.record       | Boolean | `false`           | Update the recorded cache state                |
+| cache.loadSuffixes | List    | `[]`              | List of additional state file suffixes to load |
+| cache.recordSuffix | String  | `null`            | State file suffix to use                       |
+| reactorRule        | String  | `null`            | The reactor rule to use                        |
+| moduleSet          | String  | `null`            | The moduleset in the reactor rule to use       |
 
 ## General usage
 

--- a/maven-plugins/build-cache-maven-extension/src/main/java/io/helidon/build/maven/cache/CacheConfigManager.java
+++ b/maven-plugins/build-cache-maven-extension/src/main/java/io/helidon/build/maven/cache/CacheConfigManager.java
@@ -77,7 +77,7 @@ public class CacheConfigManager {
     public LifecycleConfig lifecycleConfig(MavenProject project) {
         return lifecycleConfigCache.computeIfAbsent(project, p -> {
             String projectPath = normalizePath(root().relativize(p.getFile().toPath().toAbsolutePath()));
-            return cacheConfig().lifecyleConfig().stream()
+            return cacheConfig().lifecycleConfig().stream()
                     .filter(c -> c.matches(projectPath))
                     .findFirst()
                     .orElse(LifecycleConfig.EMPTY);

--- a/maven-plugins/build-cache-maven-extension/src/test/resources/cache-config.xml
+++ b/maven-plugins/build-cache-maven-extension/src/test/resources/cache-config.xml
@@ -18,6 +18,12 @@
 -->
 <cacheConfig>
     <enabled>true</enabled>
+    <record>true</record>
+    <loadSuffixes>
+        <suffix>foo</suffix>
+        <suffix>bar</suffix>
+    </loadSuffixes>
+    <recordSuffix>foo</recordSuffix>
     <lifecycleConfig>
         <enableChecksums>true</enableChecksums>
         <includeAllChecksums>true</includeAllChecksums>


### PR DESCRIPTION
Introduce a new mechanism that can be used to aggregate partial caches.

E.g.

```
build -> | javadoc part#1 -|
         | javadoc part#2  |-> release
         | javadoc part#3 -|
```

The javadoc jobs can use `-Dcache.recordSuffix=javadoc` to produce augmented state files with a different name. A simple glob like can be used `**/target/state-javadoc.xml` to archive only the new state.

The release job can download all javadoc artifacts, without conflicts with the state files (unless the javadoc jobs overlap). The javadoc state files can be loaded with `-Dcache.loadSuffixes=javadoc`, they will be merged with the default state files.
