### PR TITLE
Maven Archetype 3.3.0 compatibility

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -89,6 +89,7 @@ jobs:
           artifact-name: helidon-cli-dist
           artifact-path: cli/impl/target/helidon-cli.zip
           run: |
+            mvn --version
             mvn ${MAVEN_ARGS} build-cache:go-offline
             mvn ${MAVEN_ARGS} -T8 \
               -Dorg.slf4j.simpleLogger.showThreadName=true \

--- a/cli/tests/functional/src/test/java/io/helidon/build/cli/tests/CliMavenTest.java
+++ b/cli/tests/functional/src/test/java/io/helidon/build/cli/tests/CliMavenTest.java
@@ -95,7 +95,7 @@ class CliMavenTest {
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         Path mavenBinDir = mavenDirectory.resolve("apache-maven-3.1.1/bin");
         List<String> mavenArgs = List.of(
-                "archetype:generate",
+                "org.apache.maven.plugins:maven-archetype-plugin:3.2.1:generate",
                 "-DinteractiveMode=false",
                 "-DarchetypeGroupId=io.helidon.archetypes",
                 "-DarchetypeArtifactId=helidon",
@@ -266,7 +266,7 @@ class CliMavenTest {
     private void missingArtifactGroupPackageValues(String mavenVersion) {
         List<String> args = List.of(
                 "-B",
-                "archetype:generate",
+                "org.apache.maven.plugins:maven-archetype-plugin:3.2.1:generate",
                 "-DinteractiveMode=false",
                 "-DarchetypeGroupId=io.helidon.archetypes",
                 "-DarchetypeArtifactId=helidon",
@@ -281,7 +281,7 @@ class CliMavenTest {
     private void missingFlavorValue(String mavenVersion) {
         List<String> args = List.of(
                 "-B",
-                "archetype:generate",
+                "org.apache.maven.plugins:maven-archetype-plugin:3.2.1:generate",
                 "-DinteractiveMode=false",
                 "-DarchetypeGroupId=io.helidon.archetypes",
                 "-DarchetypeArtifactId=helidon",
@@ -298,7 +298,7 @@ class CliMavenTest {
     private void missingBaseValue(String mavenVersion) {
         List<String> args = List.of(
                 "-B",
-                "archetype:generate",
+                "org.apache.maven.plugins:maven-archetype-plugin:3.2.1:generate",
                 "-DinteractiveMode=false",
                 "-DarchetypeGroupId=io.helidon.archetypes",
                 "-DarchetypeArtifactId=helidon",

--- a/maven-plugins/helidon-archetype-maven-plugin/pom.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/pom.xml
@@ -61,6 +61,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-util</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
             <scope>provided</scope>

--- a/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test1/src/main/archetype/files/pom.xml.mustache
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/it/projects/test1/src/main/archetype/files/pom.xml.mustache
@@ -29,7 +29,18 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
     </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/MavenArchetypeGenerator.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/MavenArchetypeGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ class MavenArchetypeGenerator {
                 .setPackage(properties.getProperty("package"))
                 .setOutputDirectory(basedir.toString())
                 .setProperties(properties)
-                .setProjectBuildingRequest(session.getProjectBuildingRequest());
+                .setRepositorySession(session.getRepositorySession());
 
         ArchetypeGenerationResult result = new ArchetypeGenerationResult();
 

--- a/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/postgenerate/Aether.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/main/java/io/helidon/build/maven/archetype/postgenerate/Aether.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,11 @@ package io.helidon.build.maven.archetype.postgenerate;
 import java.io.File;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
-import org.apache.maven.cli.transfer.Slf4jMavenTransferListener;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
-import org.apache.maven.settings.Mirror;
-import org.apache.maven.settings.Settings;
-import org.apache.maven.settings.building.DefaultSettingsBuilder;
-import org.apache.maven.settings.building.DefaultSettingsBuilderFactory;
-import org.apache.maven.settings.building.DefaultSettingsBuildingRequest;
-import org.apache.maven.settings.building.SettingsBuildingException;
 import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.providers.http.HttpWagon;
 import org.codehaus.plexus.DefaultPlexusContainer;
@@ -36,18 +30,13 @@ import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.PlexusContainerException;
 import org.codehaus.plexus.component.composition.CycleDetectedInComponentGraphException;
 import org.codehaus.plexus.component.repository.ComponentDescriptor;
-import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
 import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.internal.transport.wagon.PlexusWagonProvider;
-import org.eclipse.aether.repository.Authentication;
-import org.eclipse.aether.repository.LocalRepository;
-import org.eclipse.aether.repository.MirrorSelector;
-import org.eclipse.aether.repository.Proxy;
-import org.eclipse.aether.repository.ProxySelector;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.resolution.ArtifactRequest;
@@ -59,9 +48,6 @@ import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.transport.wagon.WagonProvider;
 import org.eclipse.aether.transport.wagon.WagonTransporterFactory;
 import org.eclipse.aether.util.filter.DependencyFilterUtils;
-import org.eclipse.aether.util.repository.AuthenticationBuilder;
-import org.eclipse.aether.util.repository.DefaultMirrorSelector;
-import org.eclipse.aether.util.repository.DefaultProxySelector;
 
 import static java.util.stream.Collectors.toList;
 
@@ -70,123 +56,42 @@ import static java.util.stream.Collectors.toList;
  */
 final class Aether {
 
-    private final Settings settings;
     private final List<RemoteRepository> remoteRepos;
     private final RepositorySystem repoSystem;
-    private final DefaultRepositorySystemSession repoSession;
+    private final RepositorySystemSession repoSession;
 
     /**
-     * Create a new Aether instance.
+     * Create a new instance.
      *
-     * @param localRepoDir        local repository directory
-     * @param remoteArtifactRepos remote artifacts repositories
-     * @param activeProfiles      list of profile ids to activate
+     * @param repoSession repository system session
+     * @param remoteRepos remote repositories
      */
-    @SuppressWarnings("unchecked")
-    Aether(File localRepoDir, List<ArtifactRepository> remoteArtifactRepos, List<String> activeProfiles) {
-        try {
-            PlexusContainer container = new DefaultPlexusContainer();
-            container.addComponentDescriptor(plexusDesc(Wagon.class, "http", HttpWagon.class));
-            container.addComponentDescriptor(plexusDesc(Wagon.class, "https", HttpWagon.class));
-            repoSystem = MavenRepositorySystemUtils
-                    .newServiceLocator()
-                    .setServices(WagonProvider.class, new PlexusWagonProvider(container))
-                    .addService(TransporterFactory.class, WagonTransporterFactory.class)
-                    .addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class)
-                    .getService(RepositorySystem.class);
-            settings = settings();
-            if (activeProfiles != null) {
-                settings.setActiveProfiles(activeProfiles);
-            }
-            repoSession = MavenRepositorySystemUtils.newSession();
-            repoSession.setTransferListener(new Slf4jMavenTransferListener());
-            repoSession.setProxySelector(proxySelector());
-            repoSession.setMirrorSelector(mirrorSelector());
-            repoSession.setLocalRepositoryManager(repoSystem
-                    .newLocalRepositoryManager(repoSession, new LocalRepository(localRepoDir)));
-            remoteRepos = remoteArtifactRepos.stream().map(this::remoteRepo).collect(toList());
-        } catch (CycleDetectedInComponentGraphException | PlexusContainerException ex) {
-            throw new IllegalStateException(ex);
-        }
+    Aether(RepositorySystemSession repoSession, List<RemoteRepository> remoteRepos) {
+        this.repoSession = repoSession;
+        this.repoSystem = repoSystem();
+        this.remoteRepos = remoteRepos;
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes", "SameParameterValue"})
-    private static ComponentDescriptor plexusDesc(Class<?> roleClass, String roleHint, Class<?> implClass) {
-        ComponentDescriptor desc = new ComponentDescriptor();
-        desc.setRoleClass(roleClass);
-        desc.setRoleHint(roleHint);
-        desc.setImplementationClass(implClass);
-        desc.setInstantiationStrategy("per-lookup");
-        return desc;
+    /**
+     * Create a new instance.
+     *
+     * @param repoSession   repository system session
+     * @param artifactRepos remote artifact repositories
+     * @param ignored       used for pseudo overload of {@code artifactRepos}
+     */
+    Aether(RepositorySystemSession repoSession, List<ArtifactRepository> artifactRepos, boolean ignored) {
+        this.repoSession = repoSession;
+        this.repoSystem = repoSystem();
+        this.remoteRepos = artifactRepos.stream().map(this::remoteRepo).collect(Collectors.toList());
     }
 
-    private static Settings settings() {
-        DefaultSettingsBuilder builder = new DefaultSettingsBuilderFactory().newInstance();
-        DefaultSettingsBuildingRequest request = new DefaultSettingsBuildingRequest();
-        String userSettings = System.getProperty("org.apache.maven.user-settings");
-        if (userSettings == null) {
-            File userHome = new File(System.getProperty("user.home")).getAbsoluteFile();
-            request.setUserSettingsFile(new File(userHome, "/.m2/settings.xml"));
-        } else {
-            request.setUserSettingsFile(new File(userSettings));
-        }
-        String globalSettings = System.getProperty("org.apache.maven.global-settings");
-        if (globalSettings != null) {
-            request.setGlobalSettingsFile(new File(globalSettings));
-        }
-        try {
-            return builder.build(request).getEffectiveSettings();
-        } catch (SettingsBuildingException ex) {
-            throw new IllegalStateException(ex);
-        }
-    }
-
-    private MirrorSelector mirrorSelector() {
-        DefaultMirrorSelector selector = new DefaultMirrorSelector();
-        List<Mirror> mirrors = settings.getMirrors();
-        if (mirrors != null) {
-            for (Mirror mirror : mirrors) {
-                selector.add(mirror.getId(), mirror.getUrl(), mirror.getLayout(), false,
-                        mirror.getMirrorOf(), mirror.getMirrorOfLayouts());
-            }
-        }
-        return selector;
-    }
-
-    private ProxySelector proxySelector() {
-        org.apache.maven.settings.Proxy proxyDef = settings.getActiveProxy();
-        if (proxyDef != null) {
-            Authentication auth = null;
-            if (proxyDef.getUsername() != null) {
-                auth = new AuthenticationBuilder().addString(proxyDef.getUsername(), proxyDef.getPassword()).build();
-            }
-            DefaultProxySelector selector = new DefaultProxySelector();
-            Proxy proxy = new Proxy(proxyDef.getProtocol(), proxyDef.getHost(), proxyDef.getPort(), auth);
-            selector.add(proxy, proxyDef.getNonProxyHosts());
-            return selector;
-        }
-        return null;
-    }
-
-    private RemoteRepository remoteRepo(ArtifactRepository aRepo) {
-        RemoteRepository.Builder builder = new RemoteRepository.Builder(aRepo.getId(), aRepo.getLayout().getId(),
-                aRepo.getUrl());
-        ArtifactRepositoryPolicy releases = aRepo.getReleases();
-        if (releases != null) {
-            RepositoryPolicy releasePolicy = new RepositoryPolicy(releases.isEnabled(), releases.getUpdatePolicy(),
-                    releases.getChecksumPolicy());
-            builder.setReleasePolicy(releasePolicy);
-        }
-        ArtifactRepositoryPolicy snapshots = aRepo.getSnapshots();
-        if (snapshots != null) {
-            RepositoryPolicy snapshotPolicy = new RepositoryPolicy(snapshots.isEnabled(), snapshots.getUpdatePolicy(),
-                    snapshots.getChecksumPolicy());
-            builder.setSnapshotPolicy(snapshotPolicy);
-        }
-        RemoteRepository repository = builder.build();
-        return new RemoteRepository.Builder(repository)
-                .setProxy(repoSession.getProxySelector().getProxy(repository))
-                .build();
+    /**
+     * Get the repository system session.
+     *
+     * @return RepositorySystemSession
+     */
+    RepositorySystemSession repoSession() {
+        return repoSession;
     }
 
     /**
@@ -246,5 +151,53 @@ final class Aether {
             files.addAll(resolveDependencies(gav));
         }
         return files;
+    }
+
+    private RemoteRepository remoteRepo(ArtifactRepository repo) {
+        RemoteRepository.Builder builder = new RemoteRepository.Builder(repo.getId(), repo.getLayout().getId(),
+                repo.getUrl());
+        ArtifactRepositoryPolicy releases = repo.getReleases();
+        if (releases != null) {
+            RepositoryPolicy releasePolicy = new RepositoryPolicy(releases.isEnabled(), releases.getUpdatePolicy(),
+                    releases.getChecksumPolicy());
+            builder.setReleasePolicy(releasePolicy);
+        }
+        ArtifactRepositoryPolicy snapshots = repo.getSnapshots();
+        if (snapshots != null) {
+            RepositoryPolicy snapshotPolicy = new RepositoryPolicy(snapshots.isEnabled(), snapshots.getUpdatePolicy(),
+                    snapshots.getChecksumPolicy());
+            builder.setSnapshotPolicy(snapshotPolicy);
+        }
+        RemoteRepository repository = builder.build();
+        return new RemoteRepository.Builder(repository)
+                .setProxy(repoSession.getProxySelector().getProxy(repository))
+                .build();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes", "SameParameterValue"})
+    private static ComponentDescriptor plexusDesc(Class<?> roleClass, String roleHint, Class<?> implClass) {
+        ComponentDescriptor desc = new ComponentDescriptor();
+        desc.setRoleClass(roleClass);
+        desc.setRoleHint(roleHint);
+        desc.setImplementationClass(implClass);
+        desc.setInstantiationStrategy("per-lookup");
+        return desc;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static RepositorySystem repoSystem() {
+        try {
+            PlexusContainer container = new DefaultPlexusContainer();
+            container.addComponentDescriptor(plexusDesc(Wagon.class, "http", HttpWagon.class));
+            container.addComponentDescriptor(plexusDesc(Wagon.class, "https", HttpWagon.class));
+            return MavenRepositorySystemUtils
+                    .newServiceLocator()
+                    .setServices(WagonProvider.class, new PlexusWagonProvider(container))
+                    .addService(TransporterFactory.class, WagonTransporterFactory.class)
+                    .addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class)
+                    .getService(RepositorySystem.class);
+        } catch (CycleDetectedInComponentGraphException | PlexusContainerException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -122,18 +122,17 @@
         Changing these version requires approval for a new third party dependency!
         -->
         <version.lib.apache-commons>3.10</version.lib.apache-commons>
-        <version.lib.archetype-common>3.2.0</version.lib.archetype-common>
+        <version.lib.archetype-common>3.3.0</version.lib.archetype-common>
         <version.lib.asciidoctorj>2.5.11</version.lib.asciidoctorj>
         <version.lib.asm>9.5</version.lib.asm>
         <version.lib.checkstyle>10.12.6</version.lib.checkstyle>
         <version.lib.diffutils>2.2</version.lib.diffutils>
         <version.lib.doxia>1.11.1</version.lib.doxia>
         <version.lib.freemarker>2.3.23</version.lib.freemarker>
-        <version.lib.groovy>2.4.16</version.lib.groovy>
         <version.lib.gson>2.8.9</version.lib.gson>
         <version.lib.guava>32.0.1-jre</version.lib.guava>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
-        <version.lib.invoker>3.0.1</version.lib.invoker>
+        <version.lib.invoker>3.3.0</version.lib.invoker>
         <version.lib.jackson>2.11.0</version.lib.jackson>
         <version.lib.jandex>3.1.2</version.lib.jandex>
         <version.lib.jansi>1.18</version.lib.jansi>
@@ -154,8 +153,8 @@
         <version.lib.maven-enforcer>3.4.0</version.lib.maven-enforcer>
         <version.lib.maven-filtering>3.3.1</version.lib.maven-filtering>
         <version.lib.maven-plugin-testing-harness>3.3.0</version.lib.maven-plugin-testing-harness>
-        <version.lib.maven-resolver>1.4.1</version.lib.maven-resolver>
-        <version.lib.maven-settings>3.6.2</version.lib.maven-settings>
+        <version.lib.maven-resolver>1.6.3</version.lib.maven-resolver>
+        <version.lib.maven-settings>3.8.8</version.lib.maven-settings>
         <version.lib.mock-server>5.10.0</version.lib.mock-server>
         <version.lib.mustache>0.9.6</version.lib.mustache>
         <version.lib.mockito>3.10.0</version.lib.mockito>
@@ -196,7 +195,7 @@
         <version.plugin.jacoco>0.7.9</version.plugin.jacoco>
         <version.plugin.jar>3.0.2</version.plugin.jar>
         <version.plugin.javadoc>3.6.2</version.plugin.javadoc>
-        <version.plugin.invoker>3.2.2</version.plugin.invoker>
+        <version.plugin.invoker>3.8.0</version.plugin.invoker>
         <version.plugin.license>1.16</version.plugin.license>
         <version.plugin.plexus>2.1.0</version.plugin.plexus>
         <version.plugin.plugin-plugin>3.10.2</version.plugin.plugin-plugin>
@@ -467,13 +466,6 @@
                             <goal>install</goal>
                         </goals>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.codehaus.groovy</groupId>
-                            <artifactId>groovy</artifactId>
-                            <version>${version.lib.groovy}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -517,7 +509,7 @@
                         </formats>
                         <suppressionFiles>
                             <!--suppress UnresolvedMavenProperty -->
-                            <suppressionFile>${top.parent.basedir}/etc/dependency-check-suppression.xml</suppressionFile>
+                            <suppressionFile>${maven.multiModuleProjectDirectory}/etc/dependency-check-suppression.xml</suppressionFile>
                         </suppressionFiles>
                     </configuration>
                 </plugin>
@@ -930,6 +922,11 @@
             <dependency>
                 <groupId>org.apache.maven.resolver</groupId>
                 <artifactId>maven-resolver-connector-basic</artifactId>
+                <version>${version.lib.maven-resolver}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-util</artifactId>
                 <version>${version.lib.maven-resolver}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Maven Archetype 3.3.0 compatibility

- Update maven-archetype dependencies to 3.3.0
- Use reflection to work with previous versions (< 3.3.0)
- Remove groovy dependency management
- Upgrade maven-invoker-plugin and maven-invoker to 3.8.0
- Replace use of ProjectInstaller (deprecated) with RepositorySystem (aether)
- Fix owasp configuration
- Hard-code org.apache.maven.plugins:maven-archetype-plugin:3.2.1:generate in cli/tests/functional

See https://github.com/helidon-io/helidon/issues/9305