### PR TITLE
Gate usage of ensureDirectory with a lock

### DIFF
--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/CopyArtifactTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/CopyArtifactTask.java
@@ -22,8 +22,6 @@ import java.util.Map;
 
 import io.helidon.build.common.Maps;
 
-import static io.helidon.build.common.FileUtils.ensureDirectory;
-
 /**
  * Copy an artifact to a given target location.
  */
@@ -56,7 +54,7 @@ final class CopyArtifactTask extends StagingTask {
         ctx.logInfo("Copying %s to %s", resolvedGav, resolveTarget);
         Path artifact = ctx.resolve(resolvedGav);
         Path targetFile = dir.resolve(resolveTarget);
-        ensureDirectory(targetFile.getParent());
+        ctx.ensureDirectory(targetFile.getParent());
         Files.copy(artifact, targetFile);
     }
 

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/DownloadTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/DownloadTask.java
@@ -28,7 +28,6 @@ import java.util.concurrent.CompletableFuture;
 import io.helidon.build.common.NetworkConnection;
 import io.helidon.build.common.Strings;
 
-import static io.helidon.build.common.FileUtils.ensureDirectory;
 import static io.helidon.build.common.FileUtils.measuredSize;
 
 /**
@@ -63,7 +62,7 @@ final class DownloadTask extends StagingTask {
     protected void doExecute(StagingContext ctx, Path dir, Map<String, String> vars) throws IOException {
         String path = resolveVar(target(), vars);
         Path file = dir.resolve(path).normalize();
-        ensureDirectory(file.getParent());
+        ctx.ensureDirectory(file.getParent());
         URL url = new URL(resolveVar(this.url, vars));
         download(ctx, url, file);
     }

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/FileTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/FileTask.java
@@ -22,8 +22,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
-import static io.helidon.build.common.FileUtils.ensureDirectory;
-
 /**
  * Generate or copy a file to a given target location.
  */
@@ -70,7 +68,7 @@ final class FileTask extends StagingTask {
         String resolvedSource = resolveVar(source, vars);
         String resolvedContent = resolveVar(content, vars);
         Path targetFile = dir.resolve(resolvedTarget).normalize();
-        ensureDirectory(targetFile.getParent());
+        ctx.ensureDirectory(targetFile.getParent());
         if (resolvedSource != null && !resolvedSource.isEmpty()) {
             Path sourceFile = ctx.resolve(resolvedSource);
             if (!Files.exists(sourceFile)) {

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagerMojo.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagerMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
+import io.helidon.build.common.Proxies;
 import io.helidon.build.common.Unchecked;
 
 import org.apache.maven.execution.MavenSession;
@@ -168,6 +169,7 @@ public class StagerMojo extends AbstractMojo {
             factory = new StagingElementFactory();
         }
 
+        Proxies.setProxyPropertiesFromEnv();
         setProxyFromSettings();
         StagingTasks tasks = StagingAction.fromConfiguration(directories, factory);
         try {

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingContext.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingContext.java
@@ -113,6 +113,15 @@ interface StagingContext {
     }
 
     /**
+     * Ensure a directory exists.
+     *
+     * @param directory directory
+     */
+    default void ensureDirectory(Path directory) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Log an info message.
      *
      * @param msg  message, can use format

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingDirectory.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/StagingDirectory.java
@@ -21,8 +21,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-import static io.helidon.build.common.FileUtils.ensureDirectory;
-
 /**
  * Generate a directory using a set of actions.
  */
@@ -39,7 +37,7 @@ class StagingDirectory extends StagingTask {
         Path targetDir = dir.resolve(target());
         ctx.logInfo("Staging %s", targetDir);
         try {
-            ensureDirectory(targetDir);
+            ctx.ensureDirectory(targetDir);
         } catch (Throwable ex) {
             return CompletableFuture.failedFuture(ex);
         }

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/SymlinkTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/SymlinkTask.java
@@ -22,8 +22,6 @@ import java.util.Map;
 
 import io.helidon.build.common.Strings;
 
-import static io.helidon.build.common.FileUtils.ensureDirectory;
-
 /**
  * Create a symlink.
  */
@@ -56,7 +54,7 @@ final class SymlinkTask extends StagingTask {
         Path link = dir.resolve(resolveVar(target(), vars));
         Path linkTarget = link.getParent().relativize(dir.resolve(resolveVar(source, vars)));
         ctx.logInfo("Creating symlink source: %s, target: %s", link, linkTarget);
-        ensureDirectory(link.getParent());
+        ctx.ensureDirectory(link.getParent());
         Files.createSymbolicLink(link, linkTarget);
     }
 }

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/TemplateTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/TemplateTask.java
@@ -29,7 +29,6 @@ import io.helidon.build.common.Strings;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.util.DecoratedCollection;
 
-import static io.helidon.build.common.FileUtils.ensureDirectory;
 import static java.util.stream.Collectors.toMap;
 
 /**
@@ -75,7 +74,7 @@ final class TemplateTask extends StagingTask {
             throw new IllegalStateException(sourceFile + " does not exist");
         }
         Path targetFile = dir.resolve(resolvedTarget).normalize();
-        ensureDirectory(targetFile.getParent());
+        ctx.ensureDirectory(targetFile.getParent());
         try (Reader reader = Files.newBufferedReader(sourceFile);
              Writer writer = Files.newBufferedWriter(targetFile,
                      StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/UnpackArtifactTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/UnpackArtifactTask.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
 
-import static io.helidon.build.common.FileUtils.ensureDirectory;
-
 /**
  * Unpack an artifact to a given target location.
  */
@@ -74,7 +72,7 @@ final class UnpackArtifactTask extends StagingTask {
         Path artifact = ctx.resolve(resolvedGav);
         Path targetDir = dir.resolve(resolvedTarget).normalize();
         ctx.logInfo("Unpacking %s to %s", artifact, targetDir);
-        ensureDirectory(targetDir);
+        ctx.ensureDirectory(targetDir);
         ctx.unpack(artifact, targetDir, excludes, includes);
     }
 }

--- a/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/UnpackTask.java
+++ b/maven-plugins/stager-maven-plugin/src/main/java/io/helidon/build/maven/stager/UnpackTask.java
@@ -24,7 +24,6 @@ import java.util.concurrent.CompletableFuture;
 
 import io.helidon.build.common.Strings;
 
-import static io.helidon.build.common.FileUtils.ensureDirectory;
 import static io.helidon.build.common.FileUtils.fileExt;
 import static io.helidon.build.maven.stager.DownloadTask.download;
 
@@ -90,7 +89,7 @@ final class UnpackTask extends StagingTask {
         String resolvedTarget = resolveVar(target(), vars);
         Path targetDir = dir.resolve(resolvedTarget).normalize();
         ctx.logInfo("Unpacking %s to %s", tempFile, targetDir);
-        ensureDirectory(targetDir);
+        ctx.ensureDirectory(targetDir);
         ctx.unpack(tempFile, targetDir, excludes, includes);
     }
 }


### PR DESCRIPTION
Gate usage of ensureDirectory with a lock.

- Use a single lock to ensure that concurrent execution of tasks don't race on the creation of directories
- Call Proxies.setProxyPropertiesFromEnv() in StagerMojo to support proxy from environment