### PR TITLE
Maven Archetype 3.3.1 compatibility

### DIFF
--- a/maven-plugins/helidon-archetype-maven-plugin/pom.xml
+++ b/maven-plugins/helidon-archetype-maven-plugin/pom.xml
@@ -94,6 +94,7 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-archiver</artifactId>
         </dependency>
+        <!--suppress VulnerableLibrariesLocal -->
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-archiver</artifactId>


### PR DESCRIPTION
Pre-emptive changes to support Maven Archetype 3.3.1 that restores compatibility pre 3.3.0

Update reflection logic to support `getRemoteArtifactRepositories` as
- `List<ArtifactRepository>`
- `List<RemoteRepository>`
