### PR TITLE
Fix CDS archiveFile.setWritable

### DIFF
--- a/linker/src/main/java/io/helidon/build/linker/ClassDataSharing.java
+++ b/linker/src/main/java/io/helidon/build/linker/ClassDataSharing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -365,7 +365,7 @@ public final class ClassDataSharing {
             }
             if (Constants.OS == OSType.Windows) {
                 // Try to make the archive file writable so that a second run can delete the image
-                archiveFile.toFile().setWritable(true);
+                jri.resolve(archiveFile).toFile().setWritable(true);
             }
         }
 


### PR DESCRIPTION
Use `jri.resolve(archiveFile)`, as `archiveFile` is a path relative to the JRI directory.

Fixes #1078
