### PR TITLE
Fix tests consistency and clean up

### DIFF
--- a/archetype/engine-v1/src/test/java/io/helidon/build/archetype/engine/v1/ArchetypeBaseTest.java
+++ b/archetype/engine-v1/src/test/java/io/helidon/build/archetype/engine/v1/ArchetypeBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.BeforeAll;
 /**
  * Class ArchetypeBaseTest.
  */
-public class ArchetypeBaseTest {
+class ArchetypeBaseTest {
 
     static private File targetDir;
 

--- a/archetype/engine-v1/src/test/java/io/helidon/build/archetype/engine/v1/ArchetypeCatalogTest.java
+++ b/archetype/engine-v1/src/test/java/io/helidon/build/archetype/engine/v1/ArchetypeCatalogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,10 +28,10 @@ import static org.hamcrest.core.IsNull.notNullValue;
 /**
  * Tests {@link ArchetypeCatalog}.
  */
-public class ArchetypeCatalogTest {
+class ArchetypeCatalogTest {
 
     @Test
-    public void testUnmarshall() {
+    void testUnmarshall() {
         InputStream is = ArchetypeCatalogTest.class.getResourceAsStream("catalog.xml");
         assertThat(is, is(notNullValue()));
 

--- a/archetype/engine-v1/src/test/java/io/helidon/build/archetype/engine/v1/ArchetypeDescriptorTest.java
+++ b/archetype/engine-v1/src/test/java/io/helidon/build/archetype/engine/v1/ArchetypeDescriptorTest.java
@@ -43,10 +43,10 @@ import static org.hamcrest.Matchers.empty;
 /**
  * Tests {@link ArchetypeDescriptor}.
  */
-public class ArchetypeDescriptorTest {
+class ArchetypeDescriptorTest {
 
     @Test
-    public void testUnmarshall() {
+    void testUnmarshall() {
         InputStream is = getClass().getClassLoader().getResourceAsStream(ArchetypeEngine.DESCRIPTOR_RESOURCE_NAME);
         assertThat(is, is(notNullValue()));
 

--- a/archetype/engine-v1/src/test/java/io/helidon/build/archetype/engine/v1/ArchetypeEngineTest.java
+++ b/archetype/engine-v1/src/test/java/io/helidon/build/archetype/engine/v1/ArchetypeEngineTest.java
@@ -49,10 +49,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Test {@link ArchetypeEngine}.
  */
-public class ArchetypeEngineTest extends ArchetypeBaseTest {
+class ArchetypeEngineTest extends ArchetypeBaseTest {
 
     @Test
-    public void testResolveProperties() {
+    void testResolveProperties() {
         Map<String, String> props = Map.of("foo", "bar", "bar", "foo");
         assertThat(PropertyEvaluator.evaluate("${foo}", props), is("bar"));
         assertThat(PropertyEvaluator.evaluate("${xxx}", props), is(""));
@@ -67,13 +67,13 @@ public class ArchetypeEngineTest extends ArchetypeBaseTest {
     }
 
     @Test
-    public void testTransformedProperties() {
+    void testTransformedProperties() {
         Map<String, String> props = Map.of("package", "com.example.myapp");
         assertThat(PropertyEvaluator.evaluate("${package/\\./\\/}", props), is("com/example/myapp"));
     }
 
     @Test
-    public void testTransform() {
+    void testTransform() {
         Map<String, String> props = Map.of("package", "com.example.myapp");
         List<Transformation> tfs = List.of(
                 new Transformation("mustache", List.of(new Replacement("\\.mustache$", ""))),
@@ -84,7 +84,7 @@ public class ArchetypeEngineTest extends ArchetypeBaseTest {
     }
 
     @Test
-    public void testEvaluateConditional() {
+    void testEvaluateConditional() {
         Map<String, String> props1 = Map.of("prop1", "true");
         Map<String, String> props2 = Map.of("prop1", "true", "prop2", "true");
 
@@ -109,7 +109,7 @@ public class ArchetypeEngineTest extends ArchetypeBaseTest {
     }
 
     @Test
-    public void testGenerate() throws IOException {
+    void testGenerate() throws IOException {
         Map<String, String> properties = Map.of(
                 "groupId", "com.example",
                 "artifactId", "my-project",

--- a/archetype/engine-v1/src/test/java/io/helidon/build/archetype/engine/v1/ArchetypeLoaderTest.java
+++ b/archetype/engine-v1/src/test/java/io/helidon/build/archetype/engine/v1/ArchetypeLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Class ArchetypeLoaderTest.
  */
-public class ArchetypeLoaderTest extends ArchetypeBaseTest {
+class ArchetypeLoaderTest extends ArchetypeBaseTest {
 
     /**
      * Creates simple JAR file to test archetype loader.
@@ -46,7 +46,7 @@ public class ArchetypeLoaderTest extends ArchetypeBaseTest {
      * @throws IOException If an IO error occurs.
      */
     @BeforeAll
-    public static void createSimpleJar() throws IOException {
+    static void createSimpleJar() throws IOException {
         Manifest manifest = new Manifest();
         File file = unique(targetDir().toPath(), "test", ".jar").toFile();
         JarOutputStream os = new JarOutputStream(new FileOutputStream(file), manifest);
@@ -57,7 +57,7 @@ public class ArchetypeLoaderTest extends ArchetypeBaseTest {
     }
 
     @Test
-    public void testLoadFromJar() throws IOException {
+    void testLoadFromJar() throws IOException {
         File file = new File(ArchetypeLoader.class.getResource("/test.jar").getFile());
         ArchetypeLoader loader = new ArchetypeLoader(file);
         try (InputStream is = loader.loadResourceAsStream("META-INF/helidon-archetype.xml")) {
@@ -74,7 +74,7 @@ public class ArchetypeLoaderTest extends ArchetypeBaseTest {
     }
 
     @Test
-    public void testLoadFromDir() throws IOException {
+    void testLoadFromDir() throws IOException {
         ArchetypeLoader loader = new ArchetypeLoader(targetDir());
         try (InputStream is = loader.loadResourceAsStream("META-INF/helidon-archetype.xml")) {
             StringBuilder sb = new StringBuilder();
@@ -90,7 +90,7 @@ public class ArchetypeLoaderTest extends ArchetypeBaseTest {
     }
 
     @Test
-    public void testBadFile() {
+    void testBadFile() {
         Path targetDirPath = targetDir().toPath().resolve("test.properties");
         assertThrows(IOException.class, () -> new ArchetypeLoader(targetDirPath.toFile()));
     }

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/BatchInputResolverTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/BatchInputResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.notNullValue;
 /**
  * Tests {@link BatchInputResolver}.
  */
-public class BatchInputResolverTest {
+class BatchInputResolverTest {
 
     @Test
     void testInputEnumWithSingleOptionAndDefault() {

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/InputResolverTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/InputResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Tests {@link InputResolver}.
  */
-public class InputResolverTest {
+class InputResolverTest {
 
     @Test
     void testEnumOption() {

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/MergedModelTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/MergedModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.is;
 /**
  * Tests {@link MergedModel}.
  */
-public class MergedModelTest {
+class MergedModelTest {
 
     @Test
     void testResolveWithNotRootContext() {

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/MustacheSupportTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/MustacheSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -350,9 +350,9 @@ class MustacheSupportTest {
     }
 
     private static class Container {
-        public final Bar bar;
+        final Bar bar;
 
-        public Container(final Bar bar) {
+        Container(final Bar bar) {
             this.bar = bar;
         }
 

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ast/ExpressionTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ast/ExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -236,7 +236,7 @@ class ExpressionTest {
     }
 
     @Test
-    public void simpleNotEqualStringLiterals() {
+    void simpleNotEqualStringLiterals() {
         assertThat(parse("'foo' != 'bar'").eval(), is(true));
     }
 

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ast/ValidationTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ast/ValidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Tests for {@link Validation}.
  */
-public class ValidationTest {
+class ValidationTest {
 
     private final String VALIDATION_ALL_IN_ONE = "validation/validations-all-in-one.xml";
     private final String VALIDATION_EXEC =  "validation/archetype-base.xml";

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/context/ContextNodeTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/context/ContextNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class ContextNodeTest {
 
     @Test
-    public void testParentForRootNode() {
+    void testParentForRootNode() {
         ContextNode root = ContextNode.create();
         ContextValue value = root.getValue("..foo");
         assertThat(value, is(nullValue()));

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/context/ContextSerializerTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/context/ContextSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.isIn;
 class ContextSerializerTest {
 
     @Test
-    public void testSerialize() {
+    void testSerialize() {
         Map<String, String> expectedResult = Map.of(
                 "foo", "foo",
                 "foo1", "",

--- a/cli/codegen/src/test/java/io/helidon/build/cli/codegen/ASTTest.java
+++ b/cli/codegen/src/test/java/io/helidon/build/cli/codegen/ASTTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,14 +55,14 @@ class ASTTest {
     }
 
     @Test
-    public void testValidArgumentDeclarationModifiers() {
+    void testValidArgumentDeclarationModifiers() {
         assertThat(argument(DEFAULT, FINAL).modifiers(), arrayContaining(DEFAULT, FINAL));
         assertThat(argument(DEFAULT).modifiers(), arrayContaining(DEFAULT));
         assertThat(argument(FINAL).modifiers(), arrayContaining(FINAL));
     }
 
     @Test
-    public void testInvalidArgumentDeclarationModifiers(){
+    void testInvalidArgumentDeclarationModifiers(){
         IllegalArgumentException ex;
 
         ex = assertThrows(IllegalArgumentException.class,  () -> argument(FINAL, FINAL));
@@ -82,7 +82,7 @@ class ASTTest {
     }
 
     @Test
-    public void testInvalidArgumentDeclaration(){
+    void testInvalidArgumentDeclaration(){
         NullPointerException ex;
 
         ex = assertThrows(NullPointerException.class,  () -> ArgumentDeclaration.builder().type(TestClassWithSuperClass.class).name(null).build());
@@ -93,7 +93,7 @@ class ASTTest {
     }
 
     @Test
-    public void testInvalidTypeDeclaration() {
+    void testInvalidTypeDeclaration() {
         NullPointerException ex;
 
         ex = assertThrows(NullPointerException.class,  () -> ClassDeclaration.builder().type(null).build());
@@ -101,7 +101,7 @@ class ASTTest {
     }
 
     @Test
-    public void testInvalidRefCast() {
+    void testInvalidRefCast() {
         NullPointerException ex;
 
         ex = assertThrows(NullPointerException.class,  () -> refCast((TypeInfo) null, valueRef("foo")));
@@ -113,7 +113,7 @@ class ASTTest {
 
     @Test
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    public void testInvalidStaticRef() {
+    void testInvalidStaticRef() {
         NullPointerException ex;
 
         ex = assertThrows(NullPointerException.class,  () -> staticRef((TypeInfo) null));
@@ -121,7 +121,7 @@ class ASTTest {
     }
 
     @Test
-    public void testInvalidMethodDeclaration() {
+    void testInvalidMethodDeclaration() {
         NullPointerException ex;
 
         ex = assertThrows(NullPointerException.class,  () -> MethodDeclaration.builder().name(null).build());
@@ -129,7 +129,7 @@ class ASTTest {
     }
 
     @Test
-    public void testInvalidMethodInvocation() {
+    void testInvalidMethodInvocation() {
         NullPointerException ex;
 
         ex = assertThrows(NullPointerException.class,  () -> methodInvocation(null));
@@ -137,7 +137,7 @@ class ASTTest {
     }
 
     @Test
-    public void testInvalidConstructorInvocation() {
+    void testInvalidConstructorInvocation() {
         NullPointerException ex;
 
         ex = assertThrows(NullPointerException.class,  () -> constructorInvocation((TypeInfo) null));
@@ -145,7 +145,7 @@ class ASTTest {
     }
 
     @Test
-    public void testInvalidArrayLiteral() {
+    void testInvalidArrayLiteral() {
         NullPointerException ex1;
 
         ex1 = assertThrows(NullPointerException.class,  () -> arrayLiteral(null));
@@ -161,7 +161,7 @@ class ASTTest {
     }
 
     @Test
-    public void testInvalidAccessModifiers(){
+    void testInvalidAccessModifiers(){
         IllegalArgumentException ex;
 
         ex = assertThrows(IllegalArgumentException.class,  () -> field(PUBLIC, DEFAULT, PROTECTED, PRIVATE));
@@ -178,7 +178,7 @@ class ASTTest {
     }
 
     @Test
-    public void testArrayValueRefNegativeIndex(){
+    void testArrayValueRefNegativeIndex(){
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                 () -> arrayValueRef("bars", -1));
         assertThat(ex.getMessage(), is("Negative array index"));
@@ -186,14 +186,14 @@ class ASTTest {
 
     @Test
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    public void testConstructorDeclarationWithoutType() {
+    void testConstructorDeclarationWithoutType() {
         IllegalStateException ex = assertThrows(IllegalStateException.class,
                 () -> ConstructorDeclaration.builder().build().type());
         assertThat(ex.getMessage(), is("type is not set"));
     }
 
     @Test
-    public void testFieldGroup() {
+    void testFieldGroup() {
         assertThat(FieldGroup.find(field(PUBLIC, STATIC, FINAL)), is(PUBLIC_STATIC_FINAL_FIELDS));
         assertThat(FieldGroup.find(field(PUBLIC, STATIC)), is(PUBLIC_STATIC_FIELDS));
         assertThat(FieldGroup.find(field(PROTECTED, STATIC, FINAL)), is(PROTECTED_STATIC_FINAL_FIELDS));
@@ -212,7 +212,7 @@ class ASTTest {
     }
 
     @Test
-    public void testModifierDuplicates() {
+    void testModifierDuplicates() {
         assertThat(Modifiers.distinct(PUBLIC, PUBLIC), is(false));
         assertThat(Modifiers.distinct(PUBLIC, STATIC, FINAL), is(true));
         assertThat(Modifiers.distinct(PUBLIC, STATIC, STATIC), is(false));
@@ -222,7 +222,7 @@ class ASTTest {
     }
 
     @Test
-    public void testModifierContainsAny() {
+    void testModifierContainsAny() {
         assertThat(Modifiers.containsAny(Modifiers.of(DEFAULT, FINAL), DEFAULT, FINAL), is(true));
         assertThat(Modifiers.containsAny(Modifiers.of(DEFAULT), DEFAULT, FINAL), is(true));
         assertThat(Modifiers.containsAny(Modifiers.of(FINAL), DEFAULT, FINAL), is(true));
@@ -236,7 +236,7 @@ class ASTTest {
     }
 
     @Test
-    public void testModifierValidAccess() {
+    void testModifierValidAccess() {
         assertThat(Modifiers.validAccess(DEFAULT), is(true));
         assertThat(Modifiers.validAccess(DEFAULT, STATIC, FINAL), is(true));
         assertThat(Modifiers.validAccess(PRIVATE), is(true));

--- a/cli/codegen/src/test/java/io/helidon/build/cli/codegen/CommandAPTest.java
+++ b/cli/codegen/src/test/java/io/helidon/build/cli/codegen/CommandAPTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ class CommandAPTest {
             "-Werror");
 
     @Test
-    public void testCli1() throws IOException {
+    void testCli1() throws IOException {
         e2e("com/acme/cli/TestOptions.java",
                 "com/acme/cli/TestCommand1.java",
                 "com/acme/cli/TestCommand2.java",
@@ -56,12 +56,12 @@ class CommandAPTest {
     }
 
     @Test
-    public void testCliWithNestedCommandClasses() throws IOException {
+    void testCliWithNestedCommandClasses() throws IOException {
         e2e("com/acme/cli/TestCliNested.java");
     }
 
     @Test
-    public void testCommandWithoutExecution() throws IOException {
+    void testCommandWithoutExecution() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("CommandWithoutExecution", ""
                         + "package com.acme.cli;\n"
@@ -80,7 +80,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testCommandWithoutCreator() throws IOException {
+    void testCommandWithoutCreator() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("CommandWithoutCreator", ""
                         + "package com.acme.cli;\n"
@@ -102,7 +102,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testMissingCommandAnnotation() throws IOException {
+    void testMissingCommandAnnotation() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("MissingCommandAnnotation", ""
                         + "package com.acme.cli;\n"
@@ -129,7 +129,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testMissingFragmentAnnotation() throws IOException {
+    void testMissingFragmentAnnotation() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("MissingFragmentAnnotation", ""
                         + "package com.acme.cli;\n"
@@ -169,7 +169,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testFragmentDuplicatedOptions() throws IOException {
+    void testFragmentDuplicatedOptions() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("FragmentDuplicatedOptions", ""
                         + "package com.acme.cli;\n"
@@ -210,7 +210,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testOptionAlreadyDefined() throws IOException {
+    void testOptionAlreadyDefined() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("OptionAlreadyDefined", ""
                         + "package com.acme.cli;\n"
@@ -235,7 +235,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testInvalidArgumentType() throws IOException {
+    void testInvalidArgumentType() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("InvalidArgumentType", ""
                         + "package com.acme.cli;\n"
@@ -260,7 +260,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testInvalidFlagType() throws IOException {
+    void testInvalidFlagType() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("InvalidFlagType", ""
                         + "package com.acme.cli;\n"
@@ -283,7 +283,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testInvalidKeyValueType() throws IOException {
+    void testInvalidKeyValueType() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("InvalidKeyValueType", ""
                         + "package com.acme.cli;\n"
@@ -308,7 +308,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testEnumKeyValue() throws IOException {
+    void testEnumKeyValue() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("EnumKeyValue", ""
                         + "package com.acme.cli;\n"
@@ -335,7 +335,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testInvalidKeyValuesTypeParam() throws IOException {
+    void testInvalidKeyValuesTypeParam() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("InvalidKeyValuesTypeParam", ""
                         + "package com.acme.cli;\n"
@@ -361,7 +361,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testInvalidKeyValuesType() throws IOException {
+    void testInvalidKeyValuesType() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("InvalidKeyValuesType", ""
                         + "package com.acme.cli;\n"
@@ -386,7 +386,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testEmptyOptionName() throws IOException {
+    void testEmptyOptionName() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("EmptyOptionName", ""
                         + "package com.acme.cli;\n"
@@ -409,7 +409,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testInvalidOptionName() throws IOException {
+    void testInvalidOptionName() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("InvalidOptionName", ""
                         + "package com.acme.cli;\n"
@@ -432,7 +432,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testEmptyOptionDescription() throws IOException {
+    void testEmptyOptionDescription() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("EmptyOptionDescription", ""
                         + "package com.acme.cli;\n"
@@ -455,7 +455,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testEmptyCommandName() throws IOException {
+    void testEmptyCommandName() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("EmptyCommandName", ""
                         + "package com.acme.cli;\n"
@@ -478,7 +478,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testInvalidCommandName() throws IOException {
+    void testInvalidCommandName() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("InvalidCommandName", ""
                         + "package com.acme.cli;\n"
@@ -501,7 +501,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testEmptyCommandDescription() throws IOException {
+    void testEmptyCommandDescription() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("EmptyCommandDescription", ""
                         + "package com.acme.cli;\n"
@@ -524,7 +524,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testEmptyCliName() throws IOException {
+    void testEmptyCliName() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("EmptyCliName", ""
                         + "package com.acme.cli;\n"
@@ -539,7 +539,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testInvalidCliName() throws IOException {
+    void testInvalidCliName() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("InvalidCliName", ""
                         + "package com.acme.cli;\n"
@@ -554,7 +554,7 @@ class CommandAPTest {
     }
 
     @Test
-    public void testEmptyCliDescription() throws IOException {
+    void testEmptyCliDescription() throws IOException {
         CompilerHelper compiler = new CompilerHelper(new CommandAP(), COMPILER_OPTS,
                 new JavaSourceFromString("EmptyCliDescription", ""
                         + "package com.acme.cli;\n"

--- a/cli/codegen/src/test/java/io/helidon/build/cli/codegen/FileHeaderJavacPluginTest.java
+++ b/cli/codegen/src/test/java/io/helidon/build/cli/codegen/FileHeaderJavacPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ final class FileHeaderJavacPluginTest {
             "-Werror");
 
     @Test
-    public void testHeader1() throws IOException {
+    void testHeader1() throws IOException {
         String header = ""
                 + "/*\n"
                 + " * line 1\n"
@@ -55,7 +55,7 @@ final class FileHeaderJavacPluginTest {
     }
 
     @Test
-    public void testHeader2() throws IOException {
+    void testHeader2() throws IOException {
         String header = ""
                 + "/*\n"
                 + " * line 1\n"

--- a/cli/codegen/src/test/java/io/helidon/build/cli/codegen/TypeInfoTest.java
+++ b/cli/codegen/src/test/java/io/helidon/build/cli/codegen/TypeInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -336,7 +336,7 @@ class TypeInfoTest {
 
     @SupportedAnnotationTypes(value = "com.acme.TestAnnotation")
     @SupportedSourceVersion(SourceVersion.RELEASE_11)
-    public static class TestAP extends AbstractProcessor {
+    static class TestAP extends AbstractProcessor {
 
         private boolean done;
         private Set<? extends Element> elements;

--- a/cli/common/src/test/java/io/helidon/build/cli/common/ArchetypesDataTest.java
+++ b/cli/common/src/test/java/io/helidon/build/cli/common/ArchetypesDataTest.java
@@ -33,10 +33,10 @@ import static org.hamcrest.Matchers.is;
 /**
  * Tests for {@link ArchetypesData}
  */
-public class ArchetypesDataTest {
+class ArchetypesDataTest {
 
     @Test
-    public void testLoad() {
+    void testLoad() {
         Path versionsFile = testResourcePath(ArchetypesData.class, "versions/cli-data/versions.xml");
         ArchetypesData archetypesData = ArchetypesData.load(versionsFile);
         ArchetypesData.Version defaultVersion = archetypesData.rawVersions().stream()
@@ -55,7 +55,7 @@ public class ArchetypesDataTest {
     }
 
     @Test
-    public void testLatestVersion() {
+    void testLatestVersion() {
         assertThat(
                 data("2.1.3", "2.4.5", "2.0.5", "3.0.0", "3.9.8", "2.9", "4.0.0", "4.0.1-SNAPSHOT").latestVersion(),
                 is(toMavenVersion("4.0.1-SNAPSHOT")));
@@ -70,7 +70,7 @@ public class ArchetypesDataTest {
     }
 
     @Test
-    public void testLatestMajorVersions() {
+    void testLatestMajorVersions() {
         ArchetypesData data = data("2.1.3", "2.4.5", "2.0.5", "3.0.0", "3.9.8", "2.9", "4.0.0", "4.0.1-SNAPSHOT");
         assertThat(data.latestMajorVersions(), Matchers.contains("4.0.1-SNAPSHOT", "3.9.8", "2.9"));
 
@@ -85,7 +85,7 @@ public class ArchetypesDataTest {
     }
 
     @Test
-    public void testLatestMajorVersionsOrdering() {
+    void testLatestMajorVersionsOrdering() {
         ArchetypesData data = data(version("2.0.0", 100),
                 version("3.0.0", 100),
                 version("4.0.1-SNAPSHOT", 200));
@@ -100,7 +100,7 @@ public class ArchetypesDataTest {
     }
 
     @Test
-    public void testVersionOrdering() {
+    void testVersionOrdering() {
         assertThat(data(version("1.0.0", 100),
                         version("1.0.1", 100),
                         version("2.0.0", 100),
@@ -109,7 +109,7 @@ public class ArchetypesDataTest {
     }
 
     @Test
-    public void testVersionQualifierOrdering() {
+    void testVersionQualifierOrdering() {
         String version1;
         String version2;
         List<String> versions = List.of(

--- a/cli/harness/src/test/java/io/helidon/build/cli/harness/CommandMatcherTest.java
+++ b/cli/harness/src/test/java/io/helidon/build/cli/harness/CommandMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Test {@link CommandMatcher}.
  */
-public class CommandMatcherTest {
+class CommandMatcherTest {
 
     @Test
-    public void testClosestMatch() {
+    void testClosestMatch() {
         List<String> target = List.of("dev");
         assertThat(CommandMatcher.match("ddev", target), is("dev"));
         assertThat(CommandMatcher.match("deev", target), is("dev"));

--- a/cli/harness/src/test/java/io/helidon/build/cli/harness/CommandParserTest.java
+++ b/cli/harness/src/test/java/io/helidon/build/cli/harness/CommandParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,10 +43,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Test {@link CommandParser}.
  */
-public class CommandParserTest {
+class CommandParserTest {
 
     @Test
-    public void testTrim() {
+    void testTrim() {
         CommandParser parser;
         CommandParser.Resolver resolver;
         CommandParameters cmd = new CommandParameters(
@@ -65,7 +65,7 @@ public class CommandParserTest {
     }
 
     @Test
-    public void testCase() {
+    void testCase() {
         CommandParser parser;
         CommandParser.Resolver resolver;
 
@@ -102,7 +102,7 @@ public class CommandParserTest {
     }
 
     @Test
-    public void testCommandNames() {
+    void testCommandNames() {
         CommandParser parser;
 
         parser = CommandParser.create("-command", "--help");
@@ -131,7 +131,7 @@ public class CommandParserTest {
     }
 
     @Test
-    public void testOptionNames() {
+    void testOptionNames() {
         CommandParser parser;
         CommandParser.Resolver resolver;
 
@@ -160,7 +160,7 @@ public class CommandParserTest {
     }
 
     @Test
-    public void testKeyValues() {
+    void testKeyValues() {
         CommandParameters cmd = new CommandParameters(
                 new CommandModel.KeyValuesInfo<>(String.class, "foo", "Foo", true));
 
@@ -193,7 +193,7 @@ public class CommandParserTest {
     }
 
     @Test
-    public void testProperties() {
+    void testProperties() {
         CommandParser parser;
         CommandParser.Resolver resolver;
 
@@ -235,7 +235,7 @@ public class CommandParserTest {
     }
 
     @Test
-    public void testResolve() {
+    void testResolve() {
         KeyValueInfo<DAY> param = new KeyValueInfo<>(DAY.class, "day", "day of the week", null, false);
         CommandParameters cmd = new CommandParameters(param);
 
@@ -248,7 +248,7 @@ public class CommandParserTest {
     }
 
     @Test
-    public void testGlobalOptions() throws IOException {
+    void testGlobalOptions() throws IOException {
         CommandParser parser;
         CommandParser.Resolver resolver;
         GlobalOptions options;
@@ -268,13 +268,13 @@ public class CommandParserTest {
     }
 
     @Test
-    public void testVersionFlag() {
+    void testVersionFlag() {
         CommandParser parser = CommandParser.create("--version");
         assertThat(parser.commandName().get(), is("version"));
     }
 
     @Test
-    public void testDuplicateOptions() {
+    void testDuplicateOptions() {
         FlagInfo verboseFlag1 = new FlagInfo("verbose", "Verbose log level", false);
         FlagInfo verboseFlag2 = new FlagInfo("verbose", "Verbose log level", false);
         CommandParameters cmd = new CommandParameters(verboseFlag1, verboseFlag2);
@@ -291,7 +291,7 @@ public class CommandParserTest {
     }
 
     @Test
-    public void testArgsFileOptionWithExistingFile() throws URISyntaxException {
+    void testArgsFileOptionWithExistingFile() throws URISyntaxException {
         KeyValueInfo<String> param = new KeyValueInfo<>(String.class, "flavor", "flavor", null, false);
         CommandParameters cmd = new CommandParameters(param);
 
@@ -308,7 +308,7 @@ public class CommandParserTest {
     }
 
     @Test
-    public void testArgsFileOptionWithIncorrectFile() {
+    void testArgsFileOptionWithIncorrectFile() {
         UncheckedIOException e = assertThrows(
                 UncheckedIOException.class,
                 () -> CommandParser.create("command", "--args-file", "not_existing_file.txt")
@@ -317,7 +317,7 @@ public class CommandParserTest {
     }
 
     @Test
-    public void testPropsFileOptionWithExistingFile() {
+    void testPropsFileOptionWithExistingFile() {
         String packagePath = getClass().getPackageName().replaceAll("\\.", "/");
         String argsFilePath = testResourcePath(getClass(), packagePath + "/test-props-file.properties").toString();
         KeyValueInfo<String> propsFileOption = new KeyValueInfo<>(String.class, "props-file", "properties file", null, false);
@@ -333,7 +333,7 @@ public class CommandParserTest {
     }
 
     @Test
-    public void testPropsFileOptionWithIncorrectFile() {
+    void testPropsFileOptionWithIncorrectFile() {
         KeyValueInfo<String> propsFileOption = new KeyValueInfo<>(String.class, "props-file", "properties file", null, false);
         CommandParameters cmd = new CommandParameters(propsFileOption);
 

--- a/cli/harness/src/test/java/io/helidon/build/cli/harness/ExecTest.java
+++ b/cli/harness/src/test/java/io/helidon/build/cli/harness/ExecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Test the built-in commands and options.
  */
-public class ExecTest {
+class ExecTest {
 
     static final CommandRegistry REGISTRY = new TestCommandRegistry();
     static final String CLI_USAGE = resourceAsString("cli-usage.txt");
@@ -92,14 +92,14 @@ public class ExecTest {
     }
 
     @Test
-    public void testUsage() {
+    void testUsage() {
         assertThat(exec("--help"), is(CLI_USAGE));
         assertThat(exec("help"), is(CLI_USAGE));
         assertThat(exec(), is(CLI_USAGE));
     }
 
     @Test
-    public void testHelp() {
+    void testHelp() {
         assertThat(exec("help", "--help"), is(HELP_CMD_HELP));
         assertThat(exec("help", "help"), is(HELP_CMD_HELP));
         assertThat(exec("help", "simple"), is(SIMPLE_CMD_HELP));
@@ -107,14 +107,14 @@ public class ExecTest {
     }
 
     @Test
-    public void testCmd() {
+    void testCmd() {
         assertThat(exec("simple"), is("noop\n"));
         assertThat(exec("simple", "--foo"), is("foo\n"));
         assertThat(exec("simple", "--bar"), is("bar\n"));
     }
 
     @Test
-    public void testCommonOptions() {
+    void testCommonOptions() {
         assertThat(exec("common", "--key", "value"), is("value\n"));
         assertThat(exec("common", "--foo", "--key", "value"), is(equalTo("foo: value\n")));
         CommandContext context = context();
@@ -126,7 +126,7 @@ public class ExecTest {
 
     private static final class TestCommandRegistry extends CommandRegistry {
 
-        public TestCommandRegistry() {
+        TestCommandRegistry() {
             super("", "test-cli", "A test cli");
             register(new CommandWithCommonOptions());
             register(new SimpleCommand());

--- a/cli/harness/src/test/java/io/helidon/build/cli/harness/OutputHelperTest.java
+++ b/cli/harness/src/test/java/io/helidon/build/cli/harness/OutputHelperTest.java
@@ -23,6 +23,9 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+/**
+ * Test {@link OutputHelper} utility class.
+ */
 class OutputHelperTest {
 
     @Test

--- a/cli/impl/src/test/java/io/helidon/build/cli/impl/ArchetypeBrowserTest.java
+++ b/cli/impl/src/test/java/io/helidon/build/cli/impl/ArchetypeBrowserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Tests {@link ArchetypeBrowser}.
  */
-public class ArchetypeBrowserTest extends MetadataAccessTestBase {
+class ArchetypeBrowserTest extends MetadataAccessTestBase {
 
     @Test
-    public void testMpBrowser() {
+    void testMpBrowser() {
         ArchetypeBrowser browser = newBrowser(Flavor.MP);
         ArchetypeEntry entry = findEntry("bare", browser);
         assertThat(entry.name(), is("bare"));
@@ -41,7 +41,7 @@ public class ArchetypeBrowserTest extends MetadataAccessTestBase {
     }
 
     @Test
-    public void testSeBrowser() {
+    void testSeBrowser() {
         ArchetypeBrowser browser = newBrowser(Flavor.SE);
         ArchetypeEntry entry = findEntry("bare", browser);
         assertThat(entry.name(), is("bare"));

--- a/cli/impl/src/test/java/io/helidon/build/cli/impl/CommandTestBase.java
+++ b/cli/impl/src/test/java/io/helidon/build/cli/impl/CommandTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,14 +24,14 @@ import static io.helidon.build.cli.common.CliProperties.HELIDON_VERSION_PROPERTY
 /**
  * Base class for command tests.
  */
-public class CommandTestBase {
+class CommandTestBase {
 
     /**
      * Overrides version under test. This property must be propagated to all
      * forked processes.
      */
     @BeforeAll
-    public static void setHelidonVersion() {
+    static void setHelidonVersion() {
         System.setProperty(HELIDON_VERSION_PROPERTY, helidonTestVersion());
         System.setProperty(HELIDON_PLUGIN_VERSION_PROPERTY, helidonTestVersion());
     }

--- a/cli/impl/src/test/java/io/helidon/build/cli/impl/HelpCommandTest.java
+++ b/cli/impl/src/test/java/io/helidon/build/cli/impl/HelpCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.is;
 /**
  * {@code helidon help} test.
  */
-public class HelpCommandTest {
+class HelpCommandTest {
 
     @Test
     void testCliHelp() throws Exception {
@@ -34,27 +34,27 @@ public class HelpCommandTest {
     }
 
     @Test
-    public void testBuildCommandHelp() throws Exception {
+    void testBuildCommandHelp() throws Exception {
         assertCommandHelp("build");
     }
 
     @Test
-    public void testDevCommandHelp() throws Exception {
+    void testDevCommandHelp() throws Exception {
         assertCommandHelp("dev");
     }
 
     @Test
-    public void testInfoCommandHelp() throws Exception {
+    void testInfoCommandHelp() throws Exception {
         assertCommandHelp("info");
     }
 
     @Test
-    public void testInitCommandHelp() throws Exception {
+    void testInitCommandHelp() throws Exception {
         assertCommandHelp("init");
     }
 
     @Test
-    public void testVersionCommandHelp() throws Exception {
+    void testVersionCommandHelp() throws Exception {
         assertCommandHelp("version");
     }
 

--- a/cli/impl/src/test/java/io/helidon/build/cli/impl/InitCommandTest.java
+++ b/cli/impl/src/test/java/io/helidon/build/cli/impl/InitCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Class InitDefaultTest.
  */
-public class InitCommandTest extends InitCommandTestBase {
+class InitCommandTest extends InitCommandTestBase {
 
     @Override
     protected CommandInvoker.Builder commandInvoker() {
@@ -42,7 +42,7 @@ public class InitCommandTest extends InitCommandTestBase {
     }
 
     @BeforeEach
-    public void beforeEach(TestInfo info) {
+    void beforeEach(TestInfo info) {
         System.out.println("\n--- Running " + info.getDisplayName() + "----------------------------------------\n");
     }
 
@@ -83,7 +83,7 @@ public class InitCommandTest extends InitCommandTestBase {
     }
 
     @Test
-    public void testDefaults() throws Exception {
+    void testDefaults() throws Exception {
         commandInvoker()
                 .useProjectOption(true)
                 .invokeInit()
@@ -91,7 +91,7 @@ public class InitCommandTest extends InitCommandTestBase {
     }
 
     @Test
-    public void testFlavor() throws Exception {
+    void testFlavor() throws Exception {
         commandInvoker()
                 .flavor("MP")
                 .invokeInit()
@@ -99,7 +99,7 @@ public class InitCommandTest extends InitCommandTestBase {
     }
 
     @Test
-    public void testGroupId() throws Exception {
+    void testGroupId() throws Exception {
         commandInvoker()
                 .groupId("io.helidon.basicapp")
                 .invokeInit()
@@ -107,7 +107,7 @@ public class InitCommandTest extends InitCommandTestBase {
     }
 
     @Test
-    public void testArtifactId() throws Exception {
+    void testArtifactId() throws Exception {
         CommandInvoker invoker = commandInvoker()
                 .artifactId("foo-artifact")
                 .invokeInit()
@@ -116,7 +116,7 @@ public class InitCommandTest extends InitCommandTestBase {
     }
 
     @Test
-    public void testPackage() throws Exception {
+    void testPackage() throws Exception {
         commandInvoker()
                 .packageName("io.helidon.mypackage")
                 .invokeInit()
@@ -124,7 +124,7 @@ public class InitCommandTest extends InitCommandTestBase {
     }
 
     @Test
-    public void testName() throws Exception {
+    void testName() throws Exception {
         commandInvoker()
                 .projectName("mybasicproject")
                 .invokeInit()
@@ -132,7 +132,7 @@ public class InitCommandTest extends InitCommandTestBase {
     }
 
     @Test
-    public void testInteractiveSe() throws Exception {
+    void testInteractiveSe() throws Exception {
         commandInvoker()
                 .input(getClass().getResource("input.txt"))
                 .invokeInit()
@@ -140,7 +140,7 @@ public class InitCommandTest extends InitCommandTestBase {
     }
 
     @Test
-    public void testInteractiveMp() throws Exception {
+    void testInteractiveMp() throws Exception {
         commandInvoker()
                 .input(getClass().getResource("input.txt"))
                 .flavor("MP")
@@ -149,7 +149,7 @@ public class InitCommandTest extends InitCommandTestBase {
     }
 
     @Test
-    public void testInteractiveAllHelidonVersions() throws Exception {
+    void testInteractiveAllHelidonVersions() throws Exception {
         String helidonProperty = System.getProperty(HELIDON_VERSION_PROPERTY);
         System.clearProperty(HELIDON_VERSION_PROPERTY);
         String cliDataUrl = testResourcePath(getClass(), "versions")
@@ -176,7 +176,7 @@ public class InitCommandTest extends InitCommandTestBase {
     }
 
     @Test
-    public void testInteractiveLatestHelidonVersions() throws Exception {
+    void testInteractiveLatestHelidonVersions() throws Exception {
         String helidonVersionProperty = System.getProperty(HELIDON_VERSION_PROPERTY);
         System.clearProperty(HELIDON_VERSION_PROPERTY);
         String cliDataUrl = testResourcePath(getClass(), "versions")

--- a/cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataAccessTestBase.java
+++ b/cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataAccessTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import static io.helidon.build.common.maven.MavenVersion.toMavenVersion;
 /**
  * Base class for command tests that require the {@link Metadata}.
  */
-public class MetadataAccessTestBase extends CommandTestBase {
+class MetadataAccessTestBase extends CommandTestBase {
 
     private static final boolean DEBUG_PLUGIN = false;
 
@@ -44,7 +44,7 @@ public class MetadataAccessTestBase extends CommandTestBase {
      * Start the metadata server.
      */
     @BeforeAll
-    public static void startMetadataAccess() {
+    static void startMetadataAccess() {
         Path userHome = unique(TestFiles.targetDir(MetadataAccessTestBase.class), "alice");
         Config.setUserHome(userHome);
         USER_CONFIG = UserConfig.create(userHome);
@@ -74,7 +74,7 @@ public class MetadataAccessTestBase extends CommandTestBase {
      * Stop the metadata server.
      */
     @AfterAll
-    public static void stopMetadataAccess() {
+    static void stopMetadataAccess() {
         if (SERVER != null) {
             SERVER.stop();
         }
@@ -84,7 +84,7 @@ public class MetadataAccessTestBase extends CommandTestBase {
      * Get the metadata URL.
      * @return metadata URL, never {@code null}
      */
-    public String metadataUrl() {
+    String metadataUrl() {
         return METADATA_URL;
     }
 
@@ -92,7 +92,7 @@ public class MetadataAccessTestBase extends CommandTestBase {
      * Get the metadata.
      * @return metadata, never {@code null}
      */
-    public Metadata metadata() {
+    Metadata metadata() {
         return METADATA;
     }
 
@@ -100,7 +100,7 @@ public class MetadataAccessTestBase extends CommandTestBase {
      * Get the user config.
      * @return config, never {@code null}
      */
-    public UserConfig userConfig() {
+    UserConfig userConfig() {
         return USER_CONFIG;
     }
 }

--- a/cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataTest.java
+++ b/cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ import static org.hamcrest.Matchers.nullValue;
 /**
  * Unit test for class {@link Metadata}.
  */
-public class MetadataTest {
+class MetadataTest {
 
     private static final String RC1_LAST_UPDATE = VERSION_RC1 + File.separator + LAST_UPDATE_FILE_NAME;
     private static final String RC2_LAST_UPDATE = VERSION_RC2 + File.separator + LAST_UPDATE_FILE_NAME;
@@ -91,17 +91,17 @@ public class MetadataTest {
     private MetadataTestServer testServer;
 
     @BeforeAll
-    public static void beforeAll() {
+    static void beforeAll() {
         LogWriter.addRecorder(LOG_RECORDER);
     }
 
     @AfterAll
-    public static void afterAll() {
+    static void afterAll() {
         LogWriter.removeRecorder(LOG_RECORDER);
     }
 
     @BeforeEach
-    public void beforeEach(TestInfo info) {
+    void beforeEach(TestInfo info) {
         String testClassName = info.getTestClass().orElseThrow().getSimpleName();
         String testName = info.getTestMethod().orElseThrow().getName();
         Log.info("%n--- %s $(bold %s) -------------------------------------------%n", testClassName, testName);

--- a/cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataTestServer.java
+++ b/cli/impl/src/test/java/io/helidon/build/cli/impl/MetadataTestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ import static org.mockserver.model.NottableString.not;
 /**
  * Metadata server that serves local test data.
  */
-public class MetadataTestServer {
+class MetadataTestServer {
     private static final String USAGE = "Usage: [--port <port>] [--rc1 | --rc2] [--quiet] [--help]";
     private static final int DEFAULT_MAIN_PORT = 8080;
     private static final String VERBOSE_LEVEL = "INFO";
@@ -86,7 +86,7 @@ public class MetadataTestServer {
      *
      * @param args The arguments.
      */
-    public static void main(String[] args) {
+    static void main(String[] args) {
         int port = DEFAULT_MAIN_PORT;
         TestVersion defaultVersion = TestVersion.RC1;
         boolean verbose = true;
@@ -122,7 +122,7 @@ public class MetadataTestServer {
      * @param defaultVersion default version
      * @param verbose Whether to do verbose logging.
      */
-    public MetadataTestServer(TestVersion defaultVersion, boolean verbose) {
+    MetadataTestServer(TestVersion defaultVersion, boolean verbose) {
         this(freePort(), defaultVersion, verbose);
     }
 
@@ -134,7 +134,7 @@ public class MetadataTestServer {
      * @param defaultVersion default version
      */
     @SuppressWarnings("ConstantConditions")
-    public MetadataTestServer(int port, TestVersion defaultVersion, boolean verbose) {
+    MetadataTestServer(int port, TestVersion defaultVersion, boolean verbose) {
         if (MockServer.class.getClassLoader() != ClassLoader.getSystemClassLoader()) {
             final String reason = "MockServer must be in system class loader";
             Log.info("$(italic,yellow Skipping: %s)", reason);
@@ -152,7 +152,7 @@ public class MetadataTestServer {
      * @return This instance, for chaining.
      */
     @SuppressWarnings("BusyWait")
-    public MetadataTestServer start() {
+    MetadataTestServer start() {
         mockServer = ClientAndServer.startClientAndServer(port);
 
         // Set the response for "/versions.xml"
@@ -189,7 +189,7 @@ public class MetadataTestServer {
      *
      * @return The url.
      */
-    public String url() {
+    String url() {
         return url;
     }
 
@@ -198,14 +198,14 @@ public class MetadataTestServer {
      *
      * @param defaultVersion defaultVersion
      */
-    public void defaultVersion(TestVersion defaultVersion) {
+    void defaultVersion(TestVersion defaultVersion) {
         this.defaultVersion = defaultVersion;
     }
 
     /**
      * Set up the {@code /versions.xml} request.
      */
-    public void setupVersions() {
+    void setupVersions() {
         String versionElements = Stream.concat(Stream.ofNullable(defaultVersion), Arrays.stream(TestVersion.values()))
                 .distinct()
                 .map(v -> "        <version" + (defaultVersion == v ? " default=\"true\"" : "") + ">" + v + "</version>")
@@ -226,7 +226,7 @@ public class MetadataTestServer {
      * @param version The version.
      * @param data    The zip data.
      */
-    public void setupCliData(TestVersion version, byte[] data) {
+    void setupCliData(TestVersion version, byte[] data) {
         final String etag = etag(version, data);
         mockServer.upsert(zipRequestWithoutEtag(version).thenRespond(response().withHeader(ETAG_HEADER, etag)
                 .withBody(data)));
@@ -239,7 +239,7 @@ public class MetadataTestServer {
     /**
      * Stop the server.
      */
-    public void stop() {
+    void stop() {
         mockServer.stop();
     }
 

--- a/cli/impl/src/test/java/io/helidon/build/cli/impl/TestMetadata.java
+++ b/cli/impl/src/test/java/io/helidon/build/cli/impl/TestMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Test metadata constants.
  */
-public class TestMetadata {
+class TestMetadata {
 
     /**
      * Supported Helidon versions.

--- a/common/ansi/src/test/java/io/helidon/build/common/ansi/AnsiTextRendererTest.java
+++ b/common/ansi/src/test/java/io/helidon/build/common/ansi/AnsiTextRendererTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.is;
 class AnsiTextRendererTest {
 
     @BeforeAll
-    public static void beforeAllTests() {
+    static void beforeAllTests() {
         System.setProperty("jansi.force", "true");
     }
 

--- a/common/common/src/test/java/io/helidon/build/common/FileUtilsTest.java
+++ b/common/common/src/test/java/io/helidon/build/common/FileUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ import static org.hamcrest.Matchers.is;
 /**
  * Unit test for class {@link FileUtils}.
  */
-public class FileUtilsTest {
+class FileUtilsTest {
 
     private static Path outputDir;
 
@@ -61,6 +61,7 @@ public class FileUtilsTest {
 
     @Test
     @EnabledOnOs({OS.LINUX, OS.MAC})
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     void testZipPermissions() throws IOException {
         Path wd = unique(outputDir, "zip-permissions");
         Path zipDir = createZipDirectory(wd);
@@ -83,6 +84,7 @@ public class FileUtilsTest {
 
     @Test
     @EnabledOnOs(OS.WINDOWS)
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     void testZipPermissions2() throws IOException {
         Path wd = unique(outputDir, "zip-permissions");
         Path zipDir = createZipDirectory(wd);
@@ -94,6 +96,7 @@ public class FileUtilsTest {
 
     @Test
     @EnabledOnOs({OS.LINUX, OS.MAC})
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     void testZipOriginalPermissions() throws IOException {
         Path wd = unique(outputDir, "original-permissions");
         Path zipDir = createZipDirectory(wd);
@@ -130,6 +133,7 @@ public class FileUtilsTest {
 
     @Test
     @EnabledOnOs({OS.LINUX, OS.MAC})
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     void testE2ePermissions() throws IOException {
         Path wd = unique(outputDir, "e2e-permissions");
         Path zipDir = createZipDirectory(wd);

--- a/common/common/src/test/java/io/helidon/build/common/PropertyEvaluatorTest.java
+++ b/common/common/src/test/java/io/helidon/build/common/PropertyEvaluatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 class PropertyEvaluatorTest {
 
     @Test
-    public void testResolveProperties() {
+    void testResolveProperties() {
         Map<String, String> props = Map.of("foo", "bar", "bar", "foo");
         assertThat(PropertyEvaluator.evaluate("${foo}", props), is("bar"));
         assertThat(PropertyEvaluator.evaluate("${xxx}", props), is(""));

--- a/common/common/src/test/java/io/helidon/build/common/ProxiesTest.java
+++ b/common/common/src/test/java/io/helidon/build/common/ProxiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ class ProxiesTest {
     }
 
     @BeforeAll
-    public static void beforeAllTests() {
+    static void beforeAllTests() {
         sysProps = System.getProperties();
         Properties copy = new Properties();
         copy.putAll(System.getProperties());
@@ -51,7 +51,7 @@ class ProxiesTest {
     }
 
     @AfterAll
-    public static void afterAllTests() {
+    static void afterAllTests() {
         System.setProperties(sysProps);
     }
 

--- a/common/common/src/test/java/io/helidon/build/common/SourcePathTest.java
+++ b/common/common/src/test/java/io/helidon/build/common/SourcePathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,9 @@ import static org.hamcrest.Matchers.nullValue;
 /**
  * Unit test for class {@link SourcePath}.
  */
-public class SourcePathTest {
+class SourcePathTest {
 
+    @SuppressWarnings("SameParameterValue")
     private static void assertPath(boolean equals, String path1, String path2) {
         SourcePath s1 = new SourcePath(path1);
         SourcePath s2 = new SourcePath(path2);
@@ -45,7 +46,7 @@ public class SourcePathTest {
     }
 
     @Test
-    public void testEmptyPath() {
+    void testEmptyPath() {
         assertThat(new SourcePath("./").matches("*"), is(true));
         assertThat(new SourcePath("./").matches("**"), is(true));
         assertThat(new SourcePath("").matches("*"), is(true));
@@ -53,7 +54,7 @@ public class SourcePathTest {
     }
 
     @Test
-    public void testNormalization() {
+    void testNormalization() {
         assertPath(true, "./abc/def/index.html", "abc/def/index.html");
         assertPath(false, "../abc/def/index.html", "abc/def/index.html");
         assertPath(true, "/abc/def/index.html", "abc/def/index.html");
@@ -64,7 +65,7 @@ public class SourcePathTest {
     }
 
     @Test
-    public void testSinglePathMatching() {
+    void testSinglePathMatching() {
         SourcePath path = new SourcePath("abc/def/ghi/index.html");
         assertThat("empty pattern", path.matches(""), is(false));
         assertThat("identical pattern", path.matches("abc/def/ghi/index.html"), is(true));
@@ -105,7 +106,7 @@ public class SourcePathTest {
     }
 
     @Test
-    public void testFiltering() {
+    void testFiltering() {
         List<SourcePath> paths = new ArrayList<>();
         paths.add(new SourcePath("abc/def/ghi/index.html"));
         paths.add(new SourcePath("abc/def/ghi/foo.html"));
@@ -183,7 +184,7 @@ public class SourcePathTest {
     }
 
     @Test
-    public void testMatchSegment() {
+    void testMatchSegment() {
 
         // empty string, identical, wildcard only
         assertWildcardMatch(true, "", "", "both empty");

--- a/common/common/src/test/java/io/helidon/build/common/StringsTest.java
+++ b/common/common/src/test/java/io/helidon/build/common/StringsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import static org.hamcrest.Matchers.nullValue;
 /**
  * Tests {@link Strings}.
  */
-public class StringsTest {
+class StringsTest {
 
     @Test
     void testStripLeading() {

--- a/common/common/src/test/java/io/helidon/build/common/SubstitutionVariablesTest.java
+++ b/common/common/src/test/java/io/helidon/build/common/SubstitutionVariablesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,47 +37,47 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class SubstitutionVariablesTest {
 
     @Test
-    public void missingClosingBrace() {
+    void missingClosingBrace() {
         SubstitutionVariables variables = SubstitutionVariables.of(emptyMap());
         assertThrows(IllegalArgumentException.class, () -> variables.resolve("roses are ${color and violets are blue"));
     }
 
     @Test
-    public void notFoundCollapseStrategy() {
+    void notFoundCollapseStrategy() {
         SubstitutionVariables variables = SubstitutionVariables.of(Collapse, emptyMap());
         assertThat(variables, is(not(nullValue())));
         assertThat(variables.resolve("roses are ${color}"), is("roses are "));
     }
 
     @Test
-    public void notFoundAsIsStrategy() {
+    void notFoundAsIsStrategy() {
         SubstitutionVariables variables = SubstitutionVariables.of(AsIs, emptyMap());
         assertThat(variables, is(not(nullValue())));
         assertThat(variables.resolve("roses are ${color}"), is("roses are ${color}"));
     }
 
     @Test
-    public void notFoundFailStrategy() {
+    void notFoundFailStrategy() {
         SubstitutionVariables variables = SubstitutionVariables.of(Fail, emptyMap());
         assertThat(variables, is(not(nullValue())));
         assertThrows(IllegalArgumentException.class, () -> variables.resolve("roses are ${color}"));
     }
 
     @Test
-    public void maxRecursion() {
+    void maxRecursion() {
         assertMaxRecursion(AsIs);
         assertMaxRecursion(Collapse);
         assertMaxRecursion(Fail);
     }
 
     @Test
-    public void singleSubstitution() {
+    void singleSubstitution() {
         SubstitutionVariables variables = SubstitutionVariables.of(Map.of("color", "blue"));
         assertThat(variables.resolve("the sky is ${color}"), is("the sky is blue"));
     }
 
     @Test
-    public void escapedSubstitution() {
+    void escapedSubstitution() {
         SubstitutionVariables variables = SubstitutionVariables.of(Map.of("color", "red"));
         assertThat(variables.resolve("vars start with '\\${'"), is("vars start with '${'"));
 
@@ -86,14 +86,14 @@ class SubstitutionVariablesTest {
     }
 
     @Test
-    public void multipleSubstitution() {
+    void multipleSubstitution() {
         SubstitutionVariables variables = SubstitutionVariables.of(Map.of("color", "blue",
                                                                           "weather", "clear"));
         assertThat(variables.resolve("the sky is ${color} and ${weather}"), is("the sky is blue and clear"));
     }
 
     @Test
-    public void recursiveSubstitution() {
+    void recursiveSubstitution() {
         SubstitutionVariables v1 = SubstitutionVariables.of(Map.of("skyDescription", "${skyConditions}",
                                                                    "skyConditions", "${skyColor} and ${weather}",
                                                                    "skyColor", "grey",

--- a/common/markdown/src/test/java/io/helidon/build/common/markdown/MarkdownSupportTest.java
+++ b/common/markdown/src/test/java/io/helidon/build/common/markdown/MarkdownSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,14 +34,14 @@ class MarkdownSupportTest {
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
 
     @Test
-    public void coloredTextNode() {
+    void coloredTextNode() {
         assertRendering("foo {::primary}This is an info colored text{:/} boo",
                 "<p>foo <div style=\"background-color:#cce5ff; color:#004085; border-color:#b8daff;\">This is an info colored " +
                         "text</div> boo</p>\n");
     }
 
     @Test
-    public void mixedMarkdownTextNode() {
+    void mixedMarkdownTextNode() {
         assertRendering("foo **bold text** {::primary}This is an info colored text{:/} boo _italic_ \n" +
                         "```java\n" +
                         "request.content().as(JsonObject.class).thenAccept(json -> {\n" +
@@ -64,7 +64,7 @@ class MarkdownSupportTest {
     }
 
     @Test
-    public void nonexistentKramdownNode() {
+    void nonexistentKramdownNode() {
         Exception e = assertThrows(IllegalArgumentException.class, () -> {
             render("foo {::nonexistent}This is an info colored text{:/} boo");
         });
@@ -73,7 +73,7 @@ class MarkdownSupportTest {
     }
 
     @Test
-    public void otherTextNode() {
+    void otherTextNode() {
         assertRendering("foo boo",
                 "<p>foo boo</p>\n");
     }

--- a/dev-loop/dev-loop/src/test/java/io/helidon/build/devloop/clidemo/CliConfigTest.java
+++ b/dev-loop/dev-loop/src/test/java/io/helidon/build/devloop/clidemo/CliConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,19 +35,19 @@ import static org.hamcrest.Matchers.is;
  * Class CliConfigTest.
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class CliConfigTest {
+class CliConfigTest {
 
     static File configFile;
 
     @BeforeAll
-    public static void configFile() {
+    static void configFile() {
         configFile = new File(Objects.requireNonNull(
                 CliConfigTest.class.getClassLoader().getResource("helidon.properties")).getFile());
     }
 
     @Test
     @Order(1)
-    public void testCliConfigLoad1() {
+    void testCliConfigLoad1() {
         CliConfig config = new CliConfig(configFile);
         List<String> features = config.listFeatures();
         features.forEach(f -> {
@@ -59,7 +59,7 @@ public class CliConfigTest {
 
     @Test
     @Order(2)
-    public void testCliConfigLoadStore1() {
+    void testCliConfigLoadStore1() {
         CliConfig config = new CliConfig(configFile);
         config.projectDir(Path.of("/usr/tmp"));
         assertThat(pathOf(config.projectDir().get()), is("/usr/tmp"));
@@ -68,7 +68,7 @@ public class CliConfigTest {
 
     @Test
     @Order(3)
-    public void testCliConfigLoadStore2() {
+    void testCliConfigLoadStore2() {
         CliConfig config = new CliConfig(configFile);
         assertThat(pathOf(config.projectDir().get()), is("/usr/tmp"));
         config.clearProjectDir();

--- a/ide-support/lsp/lsp-server/src/test/java/io/helidon/lsp/server/management/MavenSupportTest.java
+++ b/ide-support/lsp/lsp-server/src/test/java/io/helidon/lsp/server/management/MavenSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ class MavenSupportTest {
     }
 
     @Test
-    public void ignoreFakePomFileTest() throws URISyntaxException {
+    void ignoreFakePomFileTest() throws URISyntaxException {
         Path pom = getCurrentPom();
         Path testFile = Paths.get("src/test/resources/pomTests/withoutMain/src/test.txt");
         Path resolvedPom = MavenSupport.resolvePom(testFile);
@@ -48,7 +48,7 @@ class MavenSupportTest {
     }
 
     @Test
-    public void getPomFileForCorrectMavenStructureFolderTest() {
+    void getPomFileForCorrectMavenStructureFolderTest() {
         Path pom = Paths.get("src/test/resources/pomTests/withMain/pom.xml");
         Path testFile = Paths.get("src/test/resources/pomTests/withMain/src/main/test.txt");
         Path resolvedPom = MavenSupport.resolvePom(testFile);
@@ -56,13 +56,13 @@ class MavenSupportTest {
     }
 
     @Test
-    public void getPomForFileTest() throws URISyntaxException {
+    void getPomForFileTest() throws URISyntaxException {
         Path pom = getCurrentPom();
         assertThat(pom.getFileName().toString(), is("pom.xml"));
     }
 
     @Test
-    public void getDependenciesTest() throws URISyntaxException {
+    void getDependenciesTest() throws URISyntaxException {
         Path pom = getCurrentPom();
         Set<Dependency> dependencies = MavenSupport.instance().dependencies(pom, 10000,  LOCAL_REPO_ARG);
         assertThat(dependencies.isEmpty(), is(false));

--- a/ide-support/lsp/lsp-server/src/test/java/io/helidon/lsp/server/service/config/properties/PropertiesTextDocumentHandlerTest.java
+++ b/ide-support/lsp/lsp-server/src/test/java/io/helidon/lsp/server/service/config/properties/PropertiesTextDocumentHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package io.helidon.lsp.server.service.config.properties;
 
-import java.net.URISyntaxException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -30,7 +29,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 
-public class PropertiesTextDocumentHandlerTest extends CompletionTestBase {
+class PropertiesTextDocumentHandlerTest extends CompletionTestBase {
 
     private final PropertiesTextDocumentHandler handler = PropertiesTextDocumentHandler.instance();
 
@@ -71,7 +70,7 @@ public class PropertiesTextDocumentHandlerTest extends CompletionTestBase {
     }
 
     @Test
-    public void testCompletionForAllowedValues() {
+    void testCompletionForAllowedValues() {
         List<CompletionItem> completion = completionItems(new Position(25, 31), "test-config.properties");
         assertThat(completion.size(), is(3));
         assertThat(completion.stream()
@@ -88,7 +87,7 @@ public class PropertiesTextDocumentHandlerTest extends CompletionTestBase {
     }
 
     @Test
-    public void testInsertText() {
+    void testInsertText() {
         List<CompletionItem> completion = completionItems(new Position(21, 37), "test-config.properties");
         CompletionItem completionItem =
                 completion.stream()
@@ -105,7 +104,7 @@ public class PropertiesTextDocumentHandlerTest extends CompletionTestBase {
     }
 
     @Test
-    public void testDefaultValues() {
+    void testDefaultValues() {
         List<CompletionItem> completion = completionItems(new Position(24, 14), "test-config.properties");
         CompletionItem completionItem = completionItemByLabel("server.sockets.tls.private-key.pem.key.resource.content-plain",
                 completion);
@@ -117,7 +116,7 @@ public class PropertiesTextDocumentHandlerTest extends CompletionTestBase {
     }
 
     @Test
-    public void testAllowedValues() {
+    void testAllowedValues() {
         List<CompletionItem> completion = completionItems(new Position(25, 26), "test-config.properties");
         CompletionItem completionItem = completionItemByLabel("server.sockets.tls.client-auth", completion);
         assertThat(completion.size(), is(1));

--- a/ide-support/lsp/lsp-server/src/test/java/io/helidon/lsp/server/service/config/yaml/YamlParserTest.java
+++ b/ide-support/lsp/lsp-server/src/test/java/io/helidon/lsp/server/service/config/yaml/YamlParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 class YamlParserTest {
 
     @Test
-    public void testIncorrectYaml() throws IOException {
+    void testIncorrectYaml() throws IOException {
         YamlParser yamlParser = new YamlParser();
         List<String> strings = readFile("incorrect-yaml-file.yaml");
         Map<LineResult, String> result = yamlParser.parse(strings);
@@ -53,7 +53,7 @@ class YamlParserTest {
     }
 
     @Test
-    public void testCorrectYaml() throws IOException {
+    void testCorrectYaml() throws IOException {
         YamlParser yamlParser = new YamlParser();
         List<String> strings = readFile("correct-yaml-file.yaml");
         Map<LineResult, String> result = yamlParser.parse(strings);

--- a/ide-support/lsp/lsp-server/src/test/java/io/helidon/lsp/server/service/config/yaml/YamlTextDocumentHandlerTest.java
+++ b/ide-support/lsp/lsp-server/src/test/java/io/helidon/lsp/server/service/config/yaml/YamlTextDocumentHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ class YamlTextDocumentHandlerTest extends CompletionTestBase {
     }
 
     @Test
-    public void testCompletionForAllowedValues() {
+    void testCompletionForAllowedValues() {
         List<CompletionItem> completion = completionItems(new Position(34, 19), "test-config.yaml");
         assertThat(completion.size(), is(3));
         assertThat(completion.stream()
@@ -84,7 +84,7 @@ class YamlTextDocumentHandlerTest extends CompletionTestBase {
     }
 
     @Test
-    public void testInsertText() {
+    void testInsertText() {
         List<CompletionItem> completion = completionItems(new Position(25, 4), "test-config.yaml");
         CompletionItem completionItem = completion.stream().filter(item -> item.getLabel().equals("host")).findFirst()
                                                   .orElse(null);
@@ -100,7 +100,7 @@ class YamlTextDocumentHandlerTest extends CompletionTestBase {
     }
 
     @Test
-    public void testDefaultValues() {
+    void testDefaultValues() {
         List<CompletionItem> completion = completionItems(new Position(19, 2), "test-config.yaml");
         CompletionItem completionItem = completionItemByLabel("default-authorization-provider", completion);
         assertThat(completionItem.getDocumentation().getLeft().contains("Default value"), is(false));
@@ -115,7 +115,7 @@ class YamlTextDocumentHandlerTest extends CompletionTestBase {
     }
 
     @Test
-    public void testAllowedValues() {
+    void testAllowedValues() {
         List<CompletionItem> completion = completionItems(new Position(44, 6), "test-config.yaml");
         CompletionItem completionItem = completionItemByLabel("client-auth", completion);
         assertThat(completion.size(), is(6));//7-1
@@ -126,7 +126,7 @@ class YamlTextDocumentHandlerTest extends CompletionTestBase {
     }
 
     @Test
-    public void testCompletionIncorrectConfig() {
+    void testCompletionIncorrectConfig() {
         List<CompletionItem> completion = completionItems(new Position(19, 0), "test-incorrect-config.yaml");
         assertThat(completion.size(), is(2));
 

--- a/linker/src/test/java/io/helidon/build/linker/StartScriptTest.java
+++ b/linker/src/test/java/io/helidon/build/linker/StartScriptTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ class StartScriptTest {
         return "${" + name + "TimeStamp} " + NOT_EQUAL + " \"" + timestamp + "\"";
     }
 
-    public static Matcher<String> containsString(String substring) {
+    static Matcher<String> containsString(String substring) {
         if (Constants.OS == Windows) {
             substring = substring.replace(Linux.escapedQuote(), Windows.escapedQuote());
         }

--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/VersionConfig.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/nativeimage/VersionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ public class VersionConfig {
      *
      * @return matcher
      */
+    @SuppressWarnings("unused")
     public String getMatcher() {
         return matcher;
     }

--- a/maven-plugins/enforcer-maven-plugin/src/test/java/io/helidon/build/maven/enforcer/GitIgnoreTest.java
+++ b/maven-plugins/enforcer-maven-plugin/src/test/java/io/helidon/build/maven/enforcer/GitIgnoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import static io.helidon.build.maven.enforcer.GitIgnore.create;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class GitIgnoreTest {
+class GitIgnoreTest {
 
     @Test
     void testSuffix() {

--- a/maven-plugins/enforcer-maven-plugin/src/test/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageRuleTest.java
+++ b/maven-plugins/enforcer-maven-plugin/src/test/java/io/helidon/build/maven/enforcer/nativeimage/NativeImageRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Native-image enforcer rul tests.
  */
-public class NativeImageRuleTest {
+class NativeImageRuleTest {
 
     @Test
     void testWrongMatcherConfiguration() {

--- a/maven-plugins/helidon-archetype-maven-plugin/src/test/java/io/helidon/build/maven/archetype/MustacheHelperTest.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/test/java/io/helidon/build/maven/archetype/MustacheHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ import static org.hamcrest.Matchers.is;
 /**
  * Tests {@link MustacheHelper}.
  */
-public class MustacheHelperTest {
+class MustacheHelperTest {
 
     private static final Path OUTPUT_DIR = targetDir(MustacheHelperTest.class).resolve("mustache-helper-ut");
 

--- a/maven-plugins/helidon-archetype-maven-plugin/src/test/java/io/helidon/build/maven/archetype/ValidatorTest.java
+++ b/maven-plugins/helidon-archetype-maven-plugin/src/test/java/io/helidon/build/maven/archetype/ValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.is;
 /**
  * Validator unit tests.
  */
-public class ValidatorTest {
+class ValidatorTest {
 
     private static final Node.BuilderInfo BUILDER_INFO = Node.BuilderInfo.of(
             ScriptLoader.create(),

--- a/maven-plugins/helidon-cli-maven-plugin/src/test/java/io/helidon/build/maven/cli/DevMojoLoader.java
+++ b/maven-plugins/helidon-cli-maven-plugin/src/test/java/io/helidon/build/maven/cli/DevMojoLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ import static java.util.Objects.requireNonNull;
  * Loader for {@link DevMojo} instances configured from a given project pom file.
  * Based on MavenPluginHelper.
  */
-@SuppressWarnings("UnconstructableJUnitTestCase")
+@SuppressWarnings({"UnconstructableJUnitTestCase", "JUnitMalformedDeclaration"})
 public final class DevMojoLoader extends AbstractMojoTestCase {
     private static final AtomicReference<DevMojoLoader> INSTANCE = new AtomicReference<>();
     private static final Path TARGET_DIR = TestFiles.targetDir(DevMojoLoader.class);

--- a/maven-plugins/helidon-cli-maven-plugin/src/test/java/io/helidon/build/maven/cli/DevMojoTest.java
+++ b/maven-plugins/helidon-cli-maven-plugin/src/test/java/io/helidon/build/maven/cli/DevMojoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 class DevMojoTest {
 
+    @SuppressWarnings("SameParameterValue")
     static void assertThrows(Class<?> exceptionType, Executable function, String... expectedMessageFragments) {
         try {
             function.execute();

--- a/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/BasicBackendTest.java
+++ b/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/BasicBackendTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,12 +40,12 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Tests {@link BasicBackend}.
  */
-public class BasicBackendTest {
+class BasicBackendTest {
 
     private static final Path OUTPUT_DIR = targetDir(BasicBackendTest.class).resolve("basic");
 
     @Test
-    public void testBasic1() throws Exception {
+    void testBasic1() throws Exception {
         Path sourceDir = targetDir(BasicBackendTest.class).resolve("test-classes/basic1");
 
         Site.builder()
@@ -57,7 +57,7 @@ public class BasicBackendTest {
     }
 
     @Test
-    public void testBasic2() throws Exception {
+    void testBasic2() throws Exception {
         Path sourceDir = targetDir(BasicBackendTest.class).resolve("test-classes/basic2");
 
         Site.builder()
@@ -69,7 +69,7 @@ public class BasicBackendTest {
     }
 
     @Test
-    public void testBasic3() throws Exception {
+    void testBasic3() throws Exception {
         Path sourceDir = targetDir(BasicBackendTest.class).resolve("test-classes/basic3");
 
         Site.builder()

--- a/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/ConfigTest.java
+++ b/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/ConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,13 +42,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 class ConfigTest {
 
     @Test
-    public void testNavConfig() {
+    void testNavConfig() {
         Config config = Config.create("/config/nav.yaml", ConfigTest.class, Map.of());
         verifyNav(Nav.create(config));
     }
 
     @Test
-    public void testSiteConfig() {
+    void testSiteConfig() {
         Config config = Config.create("/config/basic.yaml", ConfigTest.class, Map.of("basedir", "/ws"));
         Site site = Site.create(config);
 
@@ -98,7 +98,7 @@ class ConfigTest {
     }
 
     @Test
-    public void testVuetifyConfig() {
+    void testVuetifyConfig() {
         Config config = Config.create("/config/vuetify.yaml", ConfigTest.class, Map.of());
         Site site = Site.create(config);
 

--- a/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/LinksTest.java
+++ b/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/LinksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,10 +35,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Tests links.
  */
-public class LinksTest {
+class LinksTest {
 
     @Test
-    public void testLinks() throws DiffException, IOException {
+    void testLinks() throws DiffException, IOException {
         Path targetDir = targetDir(VuetifyBackendTest.class);
         Path sourceDir = targetDir.resolve("test-classes/links");
         Path outputDir = targetDir.resolve("links");

--- a/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/PageMetadataTest.java
+++ b/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/PageMetadataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ class PageMetadataTest {
     private static final Site SITE = Site.create(new Backend("dummy") {});
 
     @Test
-    public void testPageWithNoTitle() {
+    void testPageWithNoTitle() {
         try {
             readMetadata("no_title.adoc");
             fail("no_title.adoc is not a valid document");
@@ -48,7 +48,7 @@ class PageMetadataTest {
     }
 
     @Test
-    public void testPageWithNoDescription() {
+    void testPageWithNoDescription() {
         Metadata m = null;
         try {
             m = readMetadata("no_description.adoc");
@@ -61,7 +61,7 @@ class PageMetadataTest {
     }
 
     @Test
-    public void testPageWithTitleAndH1() {
+    void testPageWithTitleAndH1() {
         Metadata m = null;
         try {
             m = readMetadata("title_and_h1.adoc");
@@ -73,7 +73,7 @@ class PageMetadataTest {
     }
 
     @Test
-    public void testPageWithDescription() {
+    void testPageWithDescription() {
         Metadata m = null;
         try {
             m = readMetadata("with_description.adoc");
@@ -84,7 +84,7 @@ class PageMetadataTest {
     }
 
     @Test
-    public void testPageWithKeywords() {
+    void testPageWithKeywords() {
         Metadata m = null;
         try {
             m = readMetadata("with_keywords.adoc");
@@ -95,7 +95,7 @@ class PageMetadataTest {
     }
 
     @Test
-    public void testPageWithH1Prefix1() {
+    void testPageWithH1Prefix1() {
         Metadata m = null;
         try {
             m = readMetadata("with_h1prefix1.adoc");
@@ -107,7 +107,7 @@ class PageMetadataTest {
     }
 
     @Test
-    public void testPageWithH1Prefix2() {
+    void testPageWithH1Prefix2() {
         Metadata m = null;
         try {
             m = readMetadata("dir1/dir2/with_h1prefix_included.adoc");

--- a/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/VuetifyBackendTest.java
+++ b/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/VuetifyBackendTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,10 +42,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Tests {@link VuetifyBackend}.
  */
-public class VuetifyBackendTest {
+class VuetifyBackendTest {
 
     @Test
-    public void testNav1() {
+    void testNav1() {
         try {
             Nav.builder()
                .title("root")
@@ -76,7 +76,7 @@ public class VuetifyBackendTest {
     }
 
     @Test
-    public void testNav2() {
+    void testNav2() {
         try {
             Nav.builder()
                .title("root")
@@ -97,7 +97,7 @@ public class VuetifyBackendTest {
     }
 
     @Test
-    public void testVuetify1() throws Exception {
+    void testVuetify1() throws Exception {
         Path targetDir = targetDir(VuetifyBackendTest.class);
         Path sourceDir = targetDir.resolve("test-classes/vuetify1");
         Path outputDir = targetDir.resolve("vuetify/testvuetify1");
@@ -160,7 +160,7 @@ public class VuetifyBackendTest {
     }
 
     @Test
-    public void testVuetify2() {
+    void testVuetify2() {
         Path targetDir = targetDir(VuetifyBackendTest.class);
         Path sourceDir = targetDir.resolve("test-classes/vuetify2");
         Path outputDir = targetDir.resolve("vuetify/testvuetify2");

--- a/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/asciidoctor/IncludePreprocessorTest.java
+++ b/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/asciidoctor/IncludePreprocessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,13 +38,13 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests {@link IncludePreprocessor}.
  */
-public class IncludePreprocessorTest {
+class IncludePreprocessorTest {
 
-    public IncludePreprocessorTest() {
+    IncludePreprocessorTest() {
     }
 
     @Test
-    public void testSourceBlockHandling() {
+    void testSourceBlockHandling() {
         String includedContentText =
                 "public class A {\n" +
                 "  public void hi() {\n" +
@@ -76,7 +76,7 @@ public class IncludePreprocessorTest {
     }
 
     @Test
-    public void testIncludeAnalysisFromNumberedInclude() {
+    void testIncludeAnalysisFromNumberedInclude() {
         String expectedIncludeTarget = "randomStuff.adoc";
         List<String> includedContent = asList(
                 "inc line 1\n" +
@@ -101,7 +101,7 @@ public class IncludePreprocessorTest {
     }
 
     @Test
-    public void testIncludeAnalysisFromBracketedInclude() {
+    void testIncludeAnalysisFromBracketedInclude() {
         String expectedIncludeTarget = "randomStuff.adoc";
         List<String> includedContent = asList(
                 "inc 1\n" +
@@ -132,7 +132,7 @@ public class IncludePreprocessorTest {
     }
 
     @Test
-    public void testOverallConversion() throws DiffException {
+    void testOverallConversion() throws DiffException {
         /*
          * Create content containing begin-end bracketed includes, both in and
          * outside [source] blocks.
@@ -247,7 +247,7 @@ public class IncludePreprocessorTest {
     }
 
     @Test
-    public void testInitialProcessing() throws IOException, DiffException, URISyntaxException {
+    void testInitialProcessing() throws IOException, DiffException, URISyntaxException {
         String testFileDir = "preprocess-adoc";
         Path originalPath = Paths.get(testFileDir, "variousIncludes.adoc");
         List<String> originalLines = loadFromPath(originalPath);
@@ -281,7 +281,7 @@ public class IncludePreprocessorTest {
     }
 
     @Test
-    public void testSourceBlockIncludeBracketing() throws DiffException {
+    void testSourceBlockIncludeBracketing() throws DiffException {
         List<String> orig = asList(
                   "[source]\n"
                 + ".Title of the source block\n"

--- a/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/maven/GenerateMojoTest.java
+++ b/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/maven/GenerateMojoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,12 +35,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Tests {@link GenerateMojo}.
  */
-public class GenerateMojoTest {
+class GenerateMojoTest {
 
     private static final Path OUTPUT_DIR = targetDir(GenerateMojoTest.class).resolve("generate-mojo");
 
     @Test
-    public void testBasicBackendConfiguration() throws Exception {
+    void testBasicBackendConfiguration() throws Exception {
         GenerateMojo mojo = mojo("generate-mojo/pom-basic-backend.xml", OUTPUT_DIR, "generate", GenerateMojo.class);
         mojo.execute();
         Site site = mojo.getSite();
@@ -49,7 +49,7 @@ public class GenerateMojoTest {
     }
 
     @Test
-    public void testVuetifyBackendConfiguration() throws Exception {
+    void testVuetifyBackendConfiguration() throws Exception {
         GenerateMojo mojo = mojo("generate-mojo/pom-vuetify-backend.xml", OUTPUT_DIR, "generate", GenerateMojo.class);
         mojo.execute();
         Site site = mojo.getSite();

--- a/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/maven/MavenPluginHelper.java
+++ b/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/maven/MavenPluginHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public final class MavenPluginHelper extends AbstractMojoTestCase {
      * @return MavenProject
      * @throws IOException if an IO error occurs
      */
-    public static <T> T mojo(String pom, Path dir, String execName, Class<T> clazz) throws Exception {
+    static <T> T mojo(String pom, Path dir, String execName, Class<T> clazz) throws Exception {
         return LazyHolder.INSTANCE.mojo0(pom, dir, execName, clazz);
     }
 
@@ -70,7 +70,7 @@ public final class MavenPluginHelper extends AbstractMojoTestCase {
      * @return MavenProject
      * @throws IOException if an IO error occurs
      */
-    public static MavenProject newMavenProject(String pom, Path dir) throws IOException {
+    static MavenProject newMavenProject(String pom, Path dir) throws IOException {
         return LazyHolder.INSTANCE.newMavenProject0(pom, dir);
     }
 

--- a/maven-plugins/snakeyaml-codegen-maven-plugin/src/test/java/io/helidon/build/maven/snakeyaml/codegen/MavenPluginHelper.java
+++ b/maven-plugins/snakeyaml-codegen-maven-plugin/src/test/java/io/helidon/build/maven/snakeyaml/codegen/MavenPluginHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,10 @@ import org.apache.maven.project.MavenProject;
 /**
  * Maven plugin helper.
  */
-public final class MavenPluginHelper extends AbstractMojoTestCase {
+@SuppressWarnings("JUnitMalformedDeclaration")
+final class MavenPluginHelper extends AbstractMojoTestCase {
 
-    private MavenPluginHelper(){
+    private MavenPluginHelper() {
         try {
             this.setUp();
         } catch(Exception ex){
@@ -43,12 +44,11 @@ public final class MavenPluginHelper extends AbstractMojoTestCase {
         static final MavenPluginHelper INSTANCE = new MavenPluginHelper();
     }
 
-    public static MavenPluginHelper getInstance() {
+    static MavenPluginHelper getInstance() {
         return LazyHolder.INSTANCE;
     }
 
-    public MavenProject newMavenProject(String pom, File dir)
-            throws IOException {
+    MavenProject newMavenProject(String pom, File dir) throws IOException {
 
         File pomFile = getTestFile("src/test/resources/" + pom);
         org.apache.maven.model.Model model = new DefaultModelReader()
@@ -60,7 +60,7 @@ public final class MavenPluginHelper extends AbstractMojoTestCase {
         return project;
     }
 
-    public <T> T getMojo (String pom, File dir, String execName, Class<T> clazz) throws Exception {
+    <T> T getMojo (String pom, File dir, String execName, Class<T> clazz) throws Exception {
         MavenProject project = newMavenProject(pom, dir);
         MavenSession session = newMavenSession(project);
         MojoExecution execution = newMojoExecution(execName);

--- a/maven-plugins/snakeyaml-codegen-maven-plugin/src/test/java/io/helidon/build/maven/snakeyaml/codegen/TestHelper.java
+++ b/maven-plugins/snakeyaml-codegen-maven-plugin/src/test/java/io/helidon/build/maven/snakeyaml/codegen/TestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author rgrecour
  */
-public abstract class TestHelper {
-
-    public static final String SOURCE_DIR_PREFIX = "src/test/resources/";
+abstract class TestHelper {
 
     /**
      * Get the base directory path of the project.
@@ -48,7 +46,7 @@ public abstract class TestHelper {
      * @param path a relative path within the project directory
      * @return the corresponding for the given path
      */
-    public static File getFile(String path) {
+    static File getFile(String path) {
         return new File(getBasedirPath(), path);
     }
 

--- a/maven-plugins/snakeyaml-codegen-maven-plugin/src/test/java/io/helidon/build/maven/snakeyaml/codegen/TestSnakeYAMLMojo.java
+++ b/maven-plugins/snakeyaml-codegen-maven-plugin/src/test/java/io/helidon/build/maven/snakeyaml/codegen/TestSnakeYAMLMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,12 +25,12 @@ import java.util.Set;
 import static io.helidon.build.maven.snakeyaml.codegen.TestHelper.getFile;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class TestSnakeYAMLMojo {
+class TestSnakeYAMLMojo {
 
     private static final File OUTPUT_DIR = getFile("target/test/generate-mojo");
 
     @Test
-    public void testSimple() throws Exception {
+    void testSimple() throws Exception {
         SnakeYAMLMojo mojo = MavenPluginHelper.getInstance().getMojo("simpleTest/pom-one-class.xml",
                 OUTPUT_DIR, "generate", SnakeYAMLMojo.class);
         mojo.execute();
@@ -51,7 +51,7 @@ public class TestSnakeYAMLMojo {
     }
 
     @Test
-    public void testPropSub() throws Exception {
+    void testPropSub() throws Exception {
         SnakeYAMLMojo mojo = MavenPluginHelper.getInstance().getMojo("simpleTest/pom-prop-sub.xml",
                 OUTPUT_DIR, "generate", SnakeYAMLMojo.class);
         mojo.execute();
@@ -79,7 +79,7 @@ public class TestSnakeYAMLMojo {
     }
 
     @Test
-    public void testPropName() {
+    void testPropName() {
         String setterMethodName = "setMyProperty";
         assertEquals("myProperty", SnakeYAMLMojo.EndpointScanner.propertyName(setterMethodName));
 

--- a/maven-plugins/stager-maven-plugin/src/test/java/io/helidon/build/maven/stager/ConfigReaderTest.java
+++ b/maven-plugins/stager-maven-plugin/src/test/java/io/helidon/build/maven/stager/ConfigReaderTest.java
@@ -44,7 +44,7 @@ class ConfigReaderTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testConverter() throws Exception {
+    void testConverter() throws Exception {
         InputStream is = ConfigReaderTest.class.getResourceAsStream("/test-config.xml");
         assertThat(is, is(not(nullValue())));
         Reader reader = new InputStreamReader(is);


### PR DESCRIPTION
This PR improves:
 - Tests consistency with Helidon guidelines
   - class package visibility
   - method package visibility
 - Clean up
   - IDE warnings
   - unused import
   - unused field