### PR TITLE
Add support for row and column span; propagate rendering error information to the output

### DIFF
--- a/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/RenderingException.java
+++ b/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/RenderingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package io.helidon.build.maven.sitegen;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
@@ -23,9 +25,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import freemarker.template.TemplateException;
-
-import static java.lang.System.lineSeparator;
-import static java.util.stream.Collectors.joining;
 
 /**
  * An exception to represent any error occurring as part of site processing.
@@ -47,11 +46,16 @@ public class RenderingException extends RuntimeException {
      * @param errors exceptions to aggregate
      */
     public RenderingException(List<RenderingException> errors) {
-        this(errors.stream()
-                   .map(Throwable::getMessage)
-                   .collect(joining(lineSeparator())));
+        this(allErrorInfo(errors));
     }
 
+    private static String allErrorInfo(List<RenderingException> errors) {
+        StringWriter sw = new StringWriter();
+        try (PrintWriter pw = new PrintWriter(sw)) {
+            errors.forEach(t -> t.printStackTrace(pw));
+            return sw.toString();
+        }
+    }
     /**
      * Create a new instance.
      *

--- a/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/RenderingException.java
+++ b/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/RenderingException.java
@@ -16,12 +16,11 @@
 
 package io.helidon.build.maven.sitegen;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.List;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 import freemarker.template.TemplateException;
@@ -50,12 +49,20 @@ public class RenderingException extends RuntimeException {
     }
 
     private static String allErrorInfo(List<RenderingException> errors) {
-        StringWriter sw = new StringWriter();
-        try (PrintWriter pw = new PrintWriter(sw)) {
-            errors.forEach(t -> t.printStackTrace(pw));
-            return sw.toString();
-        }
+        return errors.stream()
+                .map(RenderingException::cascadeMessages)
+                .collect(Collectors.joining());
     }
+
+    private static String cascadeMessages(Throwable error){
+        StringJoiner result = new StringJoiner(System.lineSeparator());
+        while (error != null) {
+            result.add(error.getMessage());
+            error = error.getCause();
+        }
+        return result.toString();
+    }
+
     /**
      * Create a new instance.
      *

--- a/maven-plugins/sitegen-maven-plugin/src/main/resources/templates/vuetify/block_table.ftl
+++ b/maven-plugins/sitegen-maven-plugin/src/main/resources/templates/vuetify/block_table.ftl
@@ -1,5 +1,5 @@
 <#--
-  Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+  Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -50,8 +50,14 @@ TODO:
 <tr>
 <#list row.cells as cell>
 <#if cell.content?is_enumerable>
-<#list cell.content as cellcontent><td class="${cell_classes}">${cellcontent}</td></#list>
-<#else><td class="${cell_classes}">${cell.content}</td>
+<#list cell.content as cellcontent><td class="${cell_classes}"
+<#if cell.rowspan??> rowspan="${cell.rowspan}"</#if>
+<#if cell.colspan??> colspan="${cell.colspan}"</#if>
+>${cellcontent}</td></#list>
+<#else><td class="${cell_classes}"
+<#if cell.rowspan??> rowspan="${cell.rowspan}"</#if>
+<#if cell.colspan??> colspan="${cell.colspan}"</#if>
+>${cell.content}</td>
 </#if>
 </#list>
 </tr>


### PR DESCRIPTION
This PR adds support for table cell row and column spanning in the Vuetify template.

It also revises `RenderingException` so it displays all available messages about rendering errors, still including but no longer limited to the name and location within the `.adoc` file where the problem occurred.