### PR TITLE
Update archetype schema to reflect `output` element runtime behavior

### DIFF
--- a/archetype/engine-v2/src/main/schema/archetype.xsd
+++ b/archetype/engine-v2/src/main/schema/archetype.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -81,6 +81,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attributeGroup ref="a:if-group"/>
     </xs:complexType>
 
     <xs:complexType name="glob-type">
@@ -788,6 +789,7 @@
                 <xs:element name="inputs" type="a:input-types"/>
                 <xs:element name="step" type="a:step-type"/>
                 <xs:element name="validations" type="a:validations-type"/>
+                <xs:element name="output" type="a:output-type"/>
             </xs:choice>
         </xs:sequence>
     </xs:group>
@@ -843,7 +845,6 @@
         <xs:sequence>
             <xs:element name="help" type="a:help-type" minOccurs="0"/>
             <xs:group ref="a:directive-group" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="output" type="a:output-type" minOccurs="0"/>
         </xs:sequence>
         <xs:attributeGroup ref="a:input-group"/>
         <xs:attributeGroup ref="a:name-group"/>
@@ -869,7 +870,6 @@
                         <xs:sequence>
                             <xs:element name="help" type="a:help-type" minOccurs="0"/>
                             <xs:group ref="a:directive-group" minOccurs="0" maxOccurs="unbounded"/>
-                            <xs:element name="output" type="a:output-type" minOccurs="0"/>
                         </xs:sequence>
                         <xs:attribute name="value" type="xs:string" use="required">
                             <xs:annotation>
@@ -910,7 +910,6 @@
                         <xs:sequence>
                             <xs:element name="help" type="a:help-type" minOccurs="0"/>
                             <xs:group ref="a:directive-group" minOccurs="0" maxOccurs="unbounded"/>
-                            <xs:element name="output" type="a:output-type" minOccurs="0"/>
                         </xs:sequence>
                         <xs:attribute name="value" type="xs:string" use="required">
                             <xs:annotation>
@@ -1004,7 +1003,6 @@
                 <xs:element name="list" type="a:list-input-type"/>
             </xs:choice>
             <xs:group ref="a:directive-group" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="output" type="a:output-type" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -1024,8 +1022,8 @@
                 <xs:element name="source" type="a:source-type"/>
                 <xs:element name="call" type="a:call-type"/>
                 <xs:element name="inputs" type="a:input-types"/>
+                <xs:element name="output" type="a:output-type"/>
             </xs:choice>
-            <xs:element name="output" type="a:output-type" minOccurs="0"/>
         </xs:sequence>
         <xs:attributeGroup ref="a:if-group"/>
         <xs:attributeGroup ref="a:name-group"/>
@@ -1344,7 +1342,6 @@
         <xs:sequence>
             <xs:element name="help" type="a:help-type" minOccurs="0"/>
             <xs:group ref="a:directive-group" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="output" type="a:output-type" minOccurs="0"/>
         </xs:sequence>
         <xs:attribute type="xs:string" name="name" use="required">
             <xs:annotation>
@@ -1368,7 +1365,6 @@
                 <xs:element name="help" type="a:help-type" minOccurs="0"/>
                 <xs:element name="methods" type="a:method-types" minOccurs="0" />
                 <xs:group ref="a:directive-group" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element name="output" type="a:output-type" minOccurs="0"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>

--- a/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ControllerTest.java
+++ b/archetype/engine-v2/src/test/java/io/helidon/build/archetype/engine/v2/ControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.build.archetype.engine.v2;
 
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -141,6 +142,41 @@ class ControllerTest {
 
         values = modelValues(script, context);
         assertThat(values.size(), is(0));
+    }
+
+    @Test
+    void testOutput() {
+        Script script = load("controller/output.xml");
+        Context context = Context.builder()
+                .cwd(script.scriptPath().getParent())
+                .build();
+        List<String> values = modelValues(script, context);
+        Iterator<String> iterator = values.iterator();
+
+        assertThat(values.size(), is(12));
+        assertThat(iterator.next(), is("script1"));
+        assertThat(iterator.next(), is("script2"));
+        assertThat(iterator.next(), is("step1"));
+        assertThat(iterator.next(), is("step2"));
+        assertThat(iterator.next(), is("inputs1"));
+        assertThat(iterator.next(), is("inputs2"));
+        assertThat(iterator.next(), is("boolean1"));
+        assertThat(iterator.next(), is("boolean2"));
+        assertThat(iterator.next(), is("enum1"));
+        assertThat(iterator.next(), is("enum2"));
+        assertThat(iterator.next(), is("method1"));
+        assertThat(iterator.next(), is("method2"));
+    }
+
+    @Test
+    void testCall() {
+        Script script = load("controller/call.xml");
+        Context context = Context.builder()
+                .cwd(script.scriptPath().getParent())
+                .build();
+        List<String> values = modelValues(script, context);
+
+        assertThat(values, contains("blue"));
     }
 
     private static List<String> modelValues(Block block, Context context) {

--- a/archetype/engine-v2/src/test/resources/controller/call.xml
+++ b/archetype/engine-v2/src/test/resources/controller/call.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<archetype-script xmlns="https://helidon.io/archetype/2.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://helidon.io/archetype/2.0 file:/archetype.xsd">
+
+    <methods>
+        <method name="blue">
+            <output>
+                <model>
+                    <value key="color">blue</value>
+                </model>
+            </output>
+        </method>
+        <method name="red">
+            <output>
+                <model>
+                    <value key="color">red</value>
+                </model>
+            </output>
+        </method>
+    </methods>
+    <step name="step">
+        <presets>
+            <boolean path="blue">true</boolean>
+            <boolean path="red">false</boolean>
+        </presets>
+        <inputs>
+            <boolean id="blue" name="Blue" default="true"/>
+            <boolean id="red" name="Red" default="false"/>
+        </inputs>
+        <call method="blue" if="${blue}"/>
+        <call method="red" if="${red}"/>
+    </step>
+</archetype-script>

--- a/archetype/engine-v2/src/test/resources/controller/output.xml
+++ b/archetype/engine-v2/src/test/resources/controller/output.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<archetype-script xmlns="https://helidon.io/archetype/2.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-2.0.xsd">
+
+    <methods>
+        <method name="method">
+            <output>
+                <model>
+                    <value key="method1">method1</value>
+                </model>
+            </output>
+            <output>
+                <model>
+                    <value key="method2">method2</value>
+                </model>
+            </output>
+        </method>
+    </methods>
+    <output>
+        <model>
+            <value key="script1">script1</value>
+        </model>
+    </output>
+    <output>
+        <model>
+            <value key="script2">script2</value>
+        </model>
+    </output>
+    <step name="Step">
+        <output>
+            <model>
+                <value key="step1">step1</value>
+            </model>
+        </output>
+        <output>
+            <model>
+                <value key="step2">step2</value>
+            </model>
+        </output>
+        <inputs>
+            <output>
+                <model>
+                    <value key="inputs1">inputs1</value>
+                </model>
+            </output>
+            <output>
+                <model>
+                    <value key="inputs2">inputs2</value>
+                </model>
+            </output>
+        </inputs>
+        <inputs>
+            <boolean id="bool" name="Bool">
+                <output>
+                    <model>
+                        <value key="boolean1">boolean1</value>
+                    </model>
+                </output>
+                <output>
+                    <model>
+                        <value key="boolean2">boolean2</value>
+                    </model>
+                </output>
+            </boolean>
+            <enum id="enum" name="Enum" default="option">
+                <option value="option" name="Option">
+                    <output>
+                        <model>
+                            <value key="enum1">enum1</value>
+                        </model>
+                    </output>
+                    <output>
+                        <model>
+                            <value key="enum2">enum2</value>
+                        </model>
+                    </output>
+                </option>
+            </enum>
+            <list id="list" name="List">
+                <option value="option" name="Option">
+                    <output>
+                        <model>
+                            <value key="list1">list1</value>
+                        </model>
+                    </output>
+                    <output>
+                        <model>
+                            <value key="list2">list2</value>
+                        </model>
+                    </output>
+                </option>
+            </list>
+        </inputs>
+    </step>
+    <call method="method"/>
+</archetype-script>


### PR DESCRIPTION
Fixes #1096

This changes allow multiple `output` element in the same parent element and add `if` attribute to method `call`. 
