### PR TITLE
Suppress `rowspan` and `colspan` from table cells unless present AND non-zero

### DIFF
--- a/maven-plugins/sitegen-maven-plugin/src/main/resources/templates/vuetify/block_table.ftl
+++ b/maven-plugins/sitegen-maven-plugin/src/main/resources/templates/vuetify/block_table.ftl
@@ -51,12 +51,12 @@ TODO:
 <#list row.cells as cell>
 <#if cell.content?is_enumerable>
 <#list cell.content as cellcontent><td class="${cell_classes}"
-<#if cell.rowspan??> rowspan="${cell.rowspan}"</#if>
-<#if cell.colspan??> colspan="${cell.colspan}"</#if>
+<#if (cell.rowspan!0) != 0> rowspan="${cell.rowspan}"</#if>
+<#if (cell.colspan!0) != 0> colspan="${cell.colspan}"</#if>
 >${cellcontent}</td></#list>
 <#else><td class="${cell_classes}"
-<#if cell.rowspan??> rowspan="${cell.rowspan}"</#if>
-<#if cell.colspan??> colspan="${cell.colspan}"</#if>
+<#if (cell.rowspan!0) != 0> rowspan="${cell.rowspan}"</#if>
+<#if (cell.colspan!0) != 0> colspan="${cell.colspan}"</#if>
 >${cell.content}</td>
 </#if>
 </#list>


### PR DESCRIPTION
Resolves https://github.com/helidon-io/helidon/issues/9676

The previous change #1097 expected `cell.rowspan` and `cell.colspan` to be _missing_ if they had not been specified. In fact, they were present with a value of 0. So every table cell had explicit settings for both of 0.

That rendered fine in Safari but not in Chrome or Firefox.

This PR conditionalizes the span specification further by checking that the value is present _and_ non-zero before adding the corresponding `xxxspan` attribute.