### PR TITLE
4.x: Fix sitegen config substitutions

### DIFF
--- a/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/Config.java
+++ b/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,15 @@ import java.io.Reader;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -123,7 +128,7 @@ public final class Config {
     }
 
     /**
-     * Get the value as string.
+     * Get the value as a string.
      *
      * @return optional
      */
@@ -132,7 +137,7 @@ public final class Config {
     }
 
     /**
-     * Get the value as boolean.
+     * Get the value as a boolean.
      *
      * @return optional
      */
@@ -166,7 +171,7 @@ public final class Config {
      * @return optional
      */
     public <T> Optional<T> as(Class<T> type) {
-        return as(o -> cast(o, type));
+        return as(o -> convert(o, type));
     }
 
     /**
@@ -175,87 +180,99 @@ public final class Config {
      * @return optional
      */
     public Optional<List<Config>> asNodeList() {
-        return asList(e -> new Config(e, this));
-    }
-
-    /**
-     * Map the value to a list of object.
-     *
-     * @return optional
-     */
-    public Optional<List<Object>> asList() {
-        return asList(Function.identity());
-    }
-
-    /**
-     * Map the value to a list of a given type.
-     *
-     * @param type requested type
-     * @param <T>  requested type
-     * @return optional
-     */
-    public <T> Optional<List<T>> asList(Class<T> type) {
-        return asList(e -> cast(e, type));
-    }
-
-    /**
-     * Map the value to a list using a mapping function.
-     *
-     * @param mapper mapping function
-     * @param <T>    requested type
-     * @return optional
-     */
-    public <T> Optional<List<T>> asList(Function<Object, T> mapper) {
         if (value == null) {
             return Optional.empty();
         }
         if (value instanceof List) {
             return Optional.of(((List<?>) value).stream()
-                                                .map(mapper)
-                                                .collect(Collectors.toList()));
+                    .map(e -> new Config(e, this))
+                    .collect(Collectors.toList()));
         }
         throw new MappingException(value.getClass(), List.class);
     }
 
     /**
-     * Map the value to a map using a mapping function.
+     * Get the value as a list.
      *
-     * @param mapper mapping function
-     * @param <T>    requested type
      * @return optional
      */
-    public <T> Optional<Map<String, T>> asMap(Function<Object, T> mapper) {
-        if (value == null) {
-            return Optional.empty();
-        }
-        if (value instanceof Map) {
-            return Optional.of(((Map<?, ?>) value)
-                    .entrySet()
-                    .stream()
-                    .map(e -> Map.entry(e.getKey().toString(), mapper.apply(e.getValue())))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-        }
-        throw new MappingException(value.getClass(), Map.class);
+    public Optional<List<String>> asList() {
+        return asList(Function.identity());
     }
 
     /**
-     * Map the value to a map of object.
+     * Get the value as a list.
+     *
+     * @param type value type
+     * @param <T>  value type
+     * @return optional
+     */
+    public <T> Optional<List<T>> asList(Class<T> type) {
+        return asList(e -> convert(e, type));
+    }
+
+    /**
+     * Get the value as a list.
+     *
+     * @param mapper value mapper
+     * @param <T>    value type
+     * @return optional
+     */
+    public <T> Optional<List<T>> asList(Function<String, T> mapper) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        if (value instanceof List) {
+            List<T> values = new ArrayList<>();
+            traverse((prefix, entry) -> {
+                T value = mapper.apply(entry.getValue());
+                values.add(value);
+            });
+            return Optional.of(values);
+        }
+        throw new MappingException(value.getClass(), List.class);
+    }
+
+    /**
+     * Get the value as a map.
      *
      * @return optional
      */
-    public Optional<Map<String, Object>> asMap() {
+    public Optional<Map<String, String>> asMap() {
         return asMap(Function.identity());
     }
 
     /**
-     * Map the value to a map of a given type.
+     * Get the value as a map.
      *
-     * @param type requested type
-     * @param <T>  requested type
+     * @param type value type
+     * @param <T>  value type
      * @return optional
      */
     public <T> Optional<Map<String, T>> asMap(Class<T> type) {
-        return asMap(e -> cast(e, type));
+        return asMap(e -> convert(e, type));
+    }
+
+    /**
+     * Get the value as a map.
+     *
+     * @param mapper value mapper
+     * @param <T>    value type
+     * @return optional
+     */
+    public <T> Optional<Map<String, T>> asMap(Function<String, T> mapper) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        if (value instanceof Map) {
+            Map<String, T> values = new TreeMap<>();
+            traverse((prefix, entry) -> {
+                String key = prefix.isEmpty() ? entry.getKey() : prefix + "." + entry.getKey();
+                values.put(key, mapper.apply(entry.getValue()));
+            });
+            return Optional.of(values);
+        }
+        throw new MappingException(value.getClass(), Map.class);
     }
 
     /**
@@ -308,31 +325,98 @@ public final class Config {
         return create((Object) yaml.loadAs(reader, Object.class), properties);
     }
 
-    private static final Set<Class<?>> PRIMITIVE_BOXED =
-            Set.of(
-                    Boolean.class,
-                    Character.class,
-                    Byte.class,
-                    Short.class,
-                    Integer.class,
-                    Long.class,
-                    Float.class,
-                    Double.class
-            );
-
-
-    private <T> T cast(Object obj, Class<T> type) {
-        if (obj != null) {
-            if (type.equals(String.class)
-                    || obj.getClass().isPrimitive()
-                    || PRIMITIVE_BOXED.contains(obj.getClass())) {
-                return type.cast(substitutions.resolve(String.valueOf(obj)));
+    private void traverse(BiConsumer<String, Map.Entry<String, String>> visitLeaf) {
+        Deque<String> path = new ArrayDeque<>();
+        traverse((k, v) -> {
+            if (k != null) {
+                path.addLast(substitutions.resolve(k));
             }
-            if (type.isInstance(obj)) {
-                return type.cast(obj);
+        }, (k, v) -> {
+            if (!path.isEmpty()) {
+                path.removeLast();
             }
-            throw new MappingException(obj.getClass(), type);
+        }, (k, v) -> {
+            String prefix = String.join(".", path);
+            visitLeaf.accept(prefix, Map.entry(substitutions.resolve(k), substitutions.resolve(v)));
+        });
+    }
+
+    private void traverse(BiConsumer<String, Object> visitNode,
+                          BiConsumer<String, Object> postVisitNode,
+                          BiConsumer<String, String> visitLeaf) {
+
+        Deque<Object> parents = new ArrayDeque<>();
+        Deque<String> keys = new ArrayDeque<>();
+        Deque<Object> stack = new ArrayDeque<>();
+        stack.push(value);
+        while (!stack.isEmpty()) {
+            Object parent = parents.peek();
+            String key = keys.peek();
+            Object node = stack.peek();
+            if (parent == node) {
+                postVisitNode.accept(key, node);
+                stack.pop();
+                if (!stack.isEmpty()) {
+                    parents.pop();
+                    keys.pop();
+                }
+            } else if (node instanceof Map) {
+                List<? extends Map.Entry<?, ?>> entries = List.copyOf(((Map<?, ?>) node).entrySet());
+                ListIterator<? extends Map.Entry<?, ?>> it = entries.listIterator(entries.size());
+                while (it.hasPrevious()) {
+                    Map.Entry<?, ?> previous = it.previous();
+                    stack.push(previous.getValue());
+                    keys.push(previous.getKey().toString());
+                }
+                parents.push(node);
+                visitNode.accept(key, node);
+            } else if (node instanceof List) {
+                List<?> list = (List<?>) node;
+                ListIterator<?> it = list.listIterator(list.size());
+                while (it.hasPrevious()) {
+                    keys.push(String.valueOf(it.previousIndex()));
+                    stack.push(it.previous());
+                }
+                parents.push(node);
+                visitNode.accept(key, node);
+            } else {
+                visitLeaf.accept(key, String.valueOf(node));
+                stack.pop();
+                keys.pop();
+            }
         }
-        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T convert(Object obj, Class<T> type) {
+        String value = substitutions.resolve(String.valueOf(obj));
+        if (type.equals(String.class)) {
+            return (T) value;
+        }
+        if (type.equals(Boolean.class) || type.equals(boolean.class)) {
+            return (T) Boolean.valueOf(value);
+        }
+        if (type.equals(Character.class) || type.equals(char.class)) {
+            return (T) Character.valueOf(value.charAt(0));
+        }
+        if (type.equals(Byte.class) || type.equals(byte.class)) {
+            return (T) Byte.valueOf(value);
+        }
+        if (type.equals(Short.class) || type.equals(short.class)) {
+            return (T) Short.valueOf(value);
+        }
+        if (type.equals(Integer.class) || type.equals(int.class)) {
+            return (T) Integer.valueOf(value);
+        }
+        if (type.equals(Long.class) || type.equals(long.class)) {
+            return (T) Long.valueOf(value);
+        }
+        if (type.equals(Float.class) || type.equals(float.class)) {
+            return (T) Float.valueOf(value);
+        }
+        if (type.equals(Double.class) || type.equals(double.class)) {
+            return (T) Double.valueOf(value);
+        }
+        throw new MappingException(obj.getClass(), type);
     }
 }

--- a/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/VuetifyBackend.java
+++ b/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/VuetifyBackend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -382,15 +382,11 @@ public class VuetifyBackend extends Backend {
          * @return this builder
          */
         public Builder config(Config config) {
-            theme.putAll(config.get("theme")
-                               .asMap(String.class)
-                               .orElseGet(Map::of));
+            theme.putAll(config.get("theme").asMap().orElseGet(Map::of));
             home = config.get("homePage")
                          .asString()
                          .orElse(null);
-            releases.addAll(config.get("releases")
-                                  .asList(String.class)
-                                  .orElseGet(List::of));
+            releases.addAll(config.get("releases").asList().orElseGet(List::of));
             nav = config.get("navigation")
                         .asOptional()
                         .map(Nav::create)

--- a/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/asciidoctor/AsciidocEngine.java
+++ b/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/asciidoctor/AsciidocEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -296,17 +296,9 @@ public class AsciidocEngine {
          * @return this builder
          */
         public Builder config(Config config) {
-            libraries.addAll(config.get("libraries")
-                                   .asList(String.class)
-                                   .orElseGet(List::of));
-
-            attributes.putAll(config.get("attributes")
-                                    .asMap()
-                                    .orElseGet(Map::of));
-
-            imagesDir = config.get("images-dir")
-                              .asString()
-                              .orElse(null);
+            libraries.addAll(config.get("libraries").asList().orElseGet(List::of));
+            attributes.putAll(config.get("attributes").asMap().orElseGet(Map::of));
+            imagesDir = config.get("images-dir").asString().orElse(null);
             return this;
         }
 

--- a/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/freemarker/FreemarkerEngine.java
+++ b/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/freemarker/FreemarkerEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -215,12 +215,8 @@ public class FreemarkerEngine {
          * @return this builder
          */
         public Builder config(Config config) {
-            directives.putAll(config.get("directives")
-                                    .asMap(String.class)
-                                    .orElseGet(Map::of));
-            model.putAll(config.get("model")
-                               .asMap(String.class)
-                               .orElseGet(Map::of));
+            directives.putAll(config.get("directives").asMap().orElseGet(Map::of));
+            model.putAll(config.get("model").asMap().orElseGet(Map::of));
             return this;
         }
 

--- a/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/maven/GenerateMojo.java
+++ b/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/maven/GenerateMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import io.helidon.build.maven.sitegen.Config;
 import io.helidon.build.maven.sitegen.RenderingException;
 import io.helidon.build.maven.sitegen.Site;
 
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
@@ -46,6 +47,9 @@ public class GenerateMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
+
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    private MavenSession session;
 
     /**
      * Directory containing the generated site files.
@@ -88,6 +92,8 @@ public class GenerateMojo extends AbstractMojo {
         project.addCompileSourceRoot(siteSourceDirectory.getAbsolutePath());
 
         Map<String, String> properties = new HashMap<>(Maps.fromProperties(project.getProperties()));
+        properties.putAll(Maps.fromProperties(session.getUserProperties()));
+
         properties.put("project.groupId", project.getGroupId());
         properties.put("project.artifactId", project.getArtifactId());
         properties.put("project.version", project.getVersion());

--- a/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/models/Header.java
+++ b/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/models/Header.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -218,9 +218,7 @@ public class Header implements Model {
                   .map(WebResource::create)
                   .forEach(scripts::add);
 
-            meta.putAll(config.get("meta")
-                              .asMap(String.class)
-                              .orElseGet(Map::of));
+            meta.putAll(config.get("meta").asMap().orElseGet(Map::of));
             return this;
         }
 

--- a/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/models/Nav.java
+++ b/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/models/Nav.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -749,7 +749,7 @@ public final class Nav extends SourcePathFilter {
             title = config.get("title").asString().orElse(title);
             glyph = config.get("glyph").asOptional().map(Glyph::create).orElse(glyph);
             source = config.get("source").asString().orElse(source);
-            sources.addAll(config.get("sources").asList(String.class).orElse(List.of()));
+            sources.addAll(config.get("sources").asList().orElse(List.of()));
             href = config.get("href").asString().orElse(href);
             target = config.get("target").asString().orElse(target);
             dir = config.get("dir").asString().orElse(dir);

--- a/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/models/SourcePathFilter.java
+++ b/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/models/SourcePathFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,8 +177,8 @@ public abstract class SourcePathFilter implements Model {
          * @return this builder
          */
         public T config(Config config) {
-            includes.addAll(config.get("includes").asList(String.class).orElseGet(List::of));
-            excludes.addAll(config.get("excludes").asList(String.class).orElseGet(List::of));
+            includes.addAll(config.get("includes").asList().orElseGet(List::of));
+            excludes.addAll(config.get("excludes").asList().orElseGet(List::of));
             return (T) this;
         }
 

--- a/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/ConfigTest.java
+++ b/maven-plugins/sitegen-maven-plugin/src/test/java/io/helidon/build/maven/sitegen/ConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
 
 package io.helidon.build.maven.sitegen;
 
+import java.io.StringReader;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.List;
 import java.util.Map;
 
 import io.helidon.build.maven.sitegen.asciidoctor.AsciidocEngine;
@@ -37,9 +39,154 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
- * Tests config loading.
+ * Tests config.
  */
 class ConfigTest {
+
+    @Test
+    void testAsMap() {
+        Config config = Config.create("/config/map.yaml", ConfigTest.class, Map.of(
+                "alice", "alice1",
+                "key", "some-key"));
+
+        assertThat(config.get("strings").asMap().orElseThrow(), is(Map.of(
+                "foo", "foo",
+                "bar", "bar")));
+        assertThat(config.get("numbers").asMap(byte.class).orElseThrow(), is(Map.of(
+                "one", (byte) 1,
+                "two", (byte) 2,
+                "three",
+                (byte) 3)));
+        assertThat(config.get("numbers").asMap(short.class).orElseThrow(), is(Map.of(
+                "one", (short) 1,
+                "two", (short) 2,
+                "three", (short) 3)));
+        assertThat(config.get("numbers").asMap(int.class).orElseThrow(), is(Map.of(
+                "one", 1,
+                "two", 2,
+                "three", 3)));
+        assertThat(config.get("numbers").asMap(long.class).orElseThrow(), is(Map.of(
+                "one", 1L,
+                "two", 2L,
+                "three", 3L)));
+        assertThat(config.get("numbers").asMap(double.class).orElseThrow(), is(Map.of(
+                "one", 1d,
+                "two", 2d,
+                "three", 3d)));
+        assertThat(config.get("numbers").asMap(float.class).orElseThrow(), is(Map.of(
+                "one", 1f,
+                "two", 2f,
+                "three", 3f)));
+        assertThat(config.get("booleans").asMap(boolean.class).orElseThrow(), is(Map.of(
+                "t", true,
+                "f", false)));
+        assertThat(config.get("chars").asMap(char.class).orElseThrow(), is(Map.of(
+                "a", 'a',
+                "b", 'b',
+                "c", 'c')));
+
+        assertThat(config.get("complex-map").asMap().orElseThrow(), is(Map.of(
+                "foo.0.bar.bar1.0", "bar1a",
+                "foo.0.bar.bar1.1", "bar1b",
+                "foo.0.bar.bar2.0", "bar2a",
+                "foo.0.bar.bar2.1", "bar2b",
+                "foo.1.bob.bob1.0", "bob1a",
+                "foo.1.bob.bob1.1", "bob1b",
+                "foo.1.bob.bob2.0", "bob2a",
+                "foo.1.bob.bob2.1", "bob2b",
+                "alice", "alice1",
+                "some-key", "some-value"
+        )));
+    }
+
+    @Test
+    void testAsList() {
+        Config config = Config.create("/config/list.yaml", ConfigTest.class, Map.of(
+                "foo1", "foo1",
+                "foo2", "foo2"));
+
+        assertThat(config.get("strings").asList().orElseThrow(), is(List.of("foo", "bar")));
+        assertThat(config.get("numbers").asList(byte.class).orElseThrow(), is(List.of((byte) 1, (byte) 2, (byte) 3)));
+        assertThat(config.get("numbers").asList(short.class).orElseThrow(), is(List.of((short) 1, (short) 2, (short) 3)));
+        assertThat(config.get("numbers").asList(int.class).orElseThrow(), is(List.of(1, 2, 3)));
+        assertThat(config.get("numbers").asList(long.class).orElseThrow(), is(List.of(1L, 2L, 3L)));
+        assertThat(config.get("numbers").asList(double.class).orElseThrow(), is(List.of(1d, 2d, 3d)));
+        assertThat(config.get("numbers").asList(float.class).orElseThrow(), is(List.of(1f, 2f, 3f)));
+        assertThat(config.get("booleans").asList(boolean.class).orElseThrow(), is(List.of(true, false)));
+        assertThat(config.get("chars").asList(char.class).orElseThrow(), is(List.of('a', 'b', 'c')));
+
+        assertThat(config.get("simple-list").asList().orElseThrow(), is(List.of("foo1", "foo2")));
+        assertThat(config.get("complex-list").asList().orElseThrow(), is(List.of(
+                "foo1",
+                "foo2",
+                "bar1",
+                "bar2"
+        )));
+    }
+
+    @Test
+    void testAsBoolean() {
+        Config config = Config.create(new StringReader("value: true"), Map.of());
+        assertThat(config.get("value").asBoolean().orElseThrow(), is(true));
+        assertThat(config.get("value").as(Boolean.class).orElseThrow(), is(true));
+        assertThat(config.get("value").as(boolean.class).orElseThrow(), is(true));
+    }
+
+    @Test
+    void testAsString() {
+        Config config = Config.create(new StringReader("value: str"), Map.of());
+        assertThat(config.get("value").asString().orElseThrow(), is("str"));
+        assertThat(config.get("value").as(String.class).orElseThrow(), is("str"));
+    }
+
+    @Test
+    void testAsCharacter() {
+        Config config = Config.create(new StringReader("value: a"), Map.of());
+        assertThat(config.get("value").as(Character.class).orElseThrow(), is('a'));
+        assertThat(config.get("value").as(char.class).orElseThrow(), is('a'));
+    }
+
+    @Test
+    void testAsInteger() {
+        Config config = Config.create(new StringReader("value: 2"), Map.of());
+        assertThat(config.get("value").as(Integer.class).orElseThrow(), is(2));
+        assertThat(config.get("value").as(int.class).orElseThrow(), is(2));
+    }
+
+    @Test
+    void testAsLong() {
+        Config config = Config.create(new StringReader("value: 2"), Map.of());
+        assertThat(config.get("value").as(Long.class).orElseThrow(), is(2L));
+        assertThat(config.get("value").as(long.class).orElseThrow(), is(2L));
+    }
+
+    @Test
+    void testAsByte() {
+        Config config = Config.create(new StringReader("value: 2"), Map.of());
+        assertThat(config.get("value").as(Byte.class).orElseThrow(), is((byte) 2));
+        assertThat(config.get("value").as(byte.class).orElseThrow(), is((byte) 2));
+    }
+
+    @Test
+    void testAsShort() {
+        Config config = Config.create(new StringReader("value: 2"), Map.of());
+        assertThat(config.get("value").as(Short.class).orElseThrow(), is((short) 2));
+        assertThat(config.get("value").as(short.class).orElseThrow(), is((short) 2));
+    }
+
+    @Test
+    void testAsFloat() {
+        Config config = Config.create(new StringReader("value: 2"), Map.of());
+        assertThat(config.get("value").as(Float.class).orElseThrow(), is(2f));
+        assertThat(config.get("value").as(float.class).orElseThrow(), is(2f));
+    }
+
+    @Test
+    void testAsDouble() {
+        Config config = Config.create(new StringReader("value: 2"), Map.of());
+        assertThat(config.get("value").as(Double.class).orElseThrow(), is(2d));
+        assertThat(config.get("value").as(double.class).orElseThrow(), is(2d));
+    }
 
     @Test
     void testNavConfig() {
@@ -209,7 +356,6 @@ class ConfigTest {
         assertThat(nav.href(), is("https://amazon.com"));
         assertThat(nav.target(), is("_blank"));
         assertThat(nav.items().size(), is(0));
-
 
         stack.pop();
         assertThat(stack.isEmpty(), is(false));

--- a/maven-plugins/sitegen-maven-plugin/src/test/resources/config/list.yaml
+++ b/maven-plugins/sitegen-maven-plugin/src/test/resources/config/list.yaml
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+strings:
+  - foo
+  - bar
+
+numbers:
+  - 1
+  - 2
+  - 3
+
+booleans:
+  - true
+  - false
+
+chars:
+  - a
+  - b
+  - c
+
+simple-list:
+  - ${foo1}
+  - ${foo2}
+
+complex-list:
+  - foo:
+    - ${foo1}
+    - ${foo2}
+  - bar:
+    - bar1
+    - bar2

--- a/maven-plugins/sitegen-maven-plugin/src/test/resources/config/map.yaml
+++ b/maven-plugins/sitegen-maven-plugin/src/test/resources/config/map.yaml
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+strings:
+  foo: foo
+  bar: bar
+
+numbers:
+  one: 1
+  two: 2
+  three: 3
+
+booleans:
+  t: true
+  f: false
+
+chars:
+  a: a
+  b: b
+  c: c
+
+complex-map:
+  foo:
+    - bar:
+        bar1: [bar1a, bar1b]
+        bar2: [bar2a, bar2b]
+    - bob:
+        bob1: [bob1a, bob1b]
+        bob2: [bob2a, bob2b]
+  alice: ${alice}
+  ${key}: some-value


### PR DESCRIPTION
Do a depth-first traversal of the config to support substitutions in asMap and asList