### PR TITLE
Split plexus logging support to retain JDK11 support in sitegen

### DIFF
--- a/common/maven-logging/pom.xml
+++ b/common/maven-logging/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -24,12 +24,8 @@
         <artifactId>helidon-build-common-project</artifactId>
         <version>4.0.0-SNAPSHOT</version>
     </parent>
-    <artifactId>helidon-build-common-maven-plugin</artifactId>
-    <name>Helidon Build Tools Common Maven Plugin</name>
-
-    <properties>
-        <maven.compiler.release>17</maven.compiler.release>
-    </properties>
+    <artifactId>helidon-build-common-maven-logging</artifactId>
+    <name>Helidon Build Tools Common Maven Logging</name>
 
     <dependencies>
         <dependency>
@@ -39,7 +35,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.build-tools.common</groupId>
-            <artifactId>helidon-build-common-maven</artifactId>
+            <artifactId>helidon-build-common-ansi</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -47,15 +43,21 @@
             <artifactId>maven-core</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-component-metadata</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-metadata</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/common/maven-logging/src/main/java/io/helidon/build/common/maven/logging/PlexusLogWriter.java
+++ b/common/maven-logging/src/main/java/io/helidon/build/common/maven/logging/PlexusLogWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.helidon.build.common.maven.plugin;
+package io.helidon.build.common.maven.logging;
 
 import io.helidon.build.common.RichTextRenderer;
 import io.helidon.build.common.logging.LogLevel;

--- a/common/maven-logging/src/main/java/io/helidon/build/common/maven/logging/PlexusLoggerHolder.java
+++ b/common/maven-logging/src/main/java/io/helidon/build/common/maven/logging/PlexusLoggerHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.helidon.build.common.maven.plugin;
+package io.helidon.build.common.maven.logging;
 
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/common/maven-logging/src/main/java/io/helidon/build/common/maven/logging/PlexusLoggerInitializer.java
+++ b/common/maven-logging/src/main/java/io/helidon/build/common/maven/logging/PlexusLoggerInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.helidon.build.common.maven.plugin;
+package io.helidon.build.common.maven.logging;
 
 import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.codehaus.plexus.component.annotations.Component;

--- a/common/maven-logging/src/main/java/io/helidon/build/common/maven/logging/package-info.java
+++ b/common/maven-logging/src/main/java/io/helidon/build/common/maven/logging/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Helidon Build Common Maven Logging.
+ */
+package io.helidon.build.common.maven.logging;

--- a/common/maven-logging/src/main/resources/META-INF/services/io.helidon.build.common.logging.LogWriter
+++ b/common/maven-logging/src/main/resources/META-INF/services/io.helidon.build.common.logging.LogWriter
@@ -1,0 +1,1 @@
+io.helidon.build.common.maven.logging.PlexusLogWriter

--- a/common/maven-plugin/src/main/resources/META-INF/services/io.helidon.build.common.logging.LogWriter
+++ b/common/maven-plugin/src/main/resources/META-INF/services/io.helidon.build.common.logging.LogWriter
@@ -1,2 +1,0 @@
-io.helidon.build.common.maven.plugin.PlexusLogWriter
-

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@
         <module>common</module>
         <module>ansi</module>
         <module>maven</module>
+        <module>maven-logging</module>
         <module>maven-plugin</module>
         <module>maven-url-support</module>
         <module>test-utils</module>

--- a/maven-plugins/build-cache-maven-plugin/pom.xml
+++ b/maven-plugins/build-cache-maven-plugin/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2023, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -78,6 +78,11 @@
         <dependency>
             <groupId>io.helidon.build-tools.common</groupId>
             <artifactId>helidon-build-common-maven-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.build-tools.common</groupId>
+            <artifactId>helidon-build-common-maven-logging</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/maven-plugins/build-cache-maven-plugin/src/main/java/io/helidon/build/cache/plugin/GoOfflineMojo.java
+++ b/maven-plugins/build-cache-maven-plugin/src/main/java/io/helidon/build/cache/plugin/GoOfflineMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,9 +38,9 @@ import io.helidon.build.common.Strings;
 import io.helidon.build.common.logging.Log;
 import io.helidon.build.common.logging.LogLevel;
 import io.helidon.build.common.maven.MavenModel;
+import io.helidon.build.common.maven.logging.PlexusLoggerHolder;
 import io.helidon.build.common.maven.plugin.MavenArtifact;
 import io.helidon.build.common.maven.plugin.MavenFilters;
-import io.helidon.build.common.maven.plugin.PlexusLoggerHolder;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.BuildBase;

--- a/maven-plugins/enforcer-maven-plugin/pom.xml
+++ b/maven-plugins/enforcer-maven-plugin/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.build-tools.common</groupId>
-            <artifactId>helidon-build-common-maven-plugin</artifactId>
+            <artifactId>helidon-build-common-maven-logging</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/maven-plugins/helidon-cli-maven-plugin/pom.xml
+++ b/maven-plugins/helidon-cli-maven-plugin/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.build-tools.common</groupId>
-            <artifactId>helidon-build-common-maven-plugin</artifactId>
+            <artifactId>helidon-build-common-maven-logging</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/maven-plugins/helidon-maven-plugin/pom.xml
+++ b/maven-plugins/helidon-maven-plugin/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.build-tools.common</groupId>
-            <artifactId>helidon-build-common-maven-plugin</artifactId>
+            <artifactId>helidon-build-common-maven-logging</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/maven-plugins/javadoc-maven-plugin/pom.xml
+++ b/maven-plugins/javadoc-maven-plugin/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2023, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -83,6 +83,11 @@
         <dependency>
             <groupId>io.helidon.build-tools.common</groupId>
             <artifactId>helidon-build-common-maven-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.build-tools.common</groupId>
+            <artifactId>helidon-build-common-maven-logging</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/maven-plugins/javadoc-maven-plugin/src/main/java/io/helidon/build/javadoc/JavadocMojo.java
+++ b/maven-plugins/javadoc-maven-plugin/src/main/java/io/helidon/build/javadoc/JavadocMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,9 +51,9 @@ import io.helidon.build.common.Strings;
 import io.helidon.build.common.logging.Log;
 import io.helidon.build.common.logging.LogLevel;
 import io.helidon.build.common.maven.MavenModel;
+import io.helidon.build.common.maven.logging.PlexusLoggerHolder;
 import io.helidon.build.common.maven.plugin.MavenArtifact;
 import io.helidon.build.common.maven.plugin.MavenFilters;
-import io.helidon.build.common.maven.plugin.PlexusLoggerHolder;
 import io.helidon.build.javadoc.JavadocModule.CompositeJavadocModule;
 import io.helidon.build.javadoc.JavadocModule.JarModule;
 import io.helidon.build.javadoc.JavadocModule.SourceModule;

--- a/maven-plugins/services-maven-plugin/pom.xml
+++ b/maven-plugins/services-maven-plugin/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.build-tools.common</groupId>
-            <artifactId>helidon-build-common-maven-plugin</artifactId>
+            <artifactId>helidon-build-common-maven-logging</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/maven-plugins/sitegen-maven-plugin/pom.xml
+++ b/maven-plugins/sitegen-maven-plugin/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.build-tools.common</groupId>
-            <artifactId>helidon-build-common-maven-plugin</artifactId>
+            <artifactId>helidon-build-common-maven-logging</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/maven/GenerateMojo.java
+++ b/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/maven/GenerateMojo.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.helidon.build.common.Maps;
-import io.helidon.build.common.maven.plugin.PlexusLoggerHolder;
+import io.helidon.build.common.maven.logging.PlexusLoggerHolder;
 import io.helidon.build.maven.sitegen.Config;
 import io.helidon.build.maven.sitegen.RenderingException;
 import io.helidon.build.maven.sitegen.Site;

--- a/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/maven/PackageMojo.java
+++ b/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/maven/PackageMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package io.helidon.build.maven.sitegen.maven;
 import java.io.File;
 import java.io.IOException;
 
-import io.helidon.build.common.maven.plugin.PlexusLoggerHolder;
+import io.helidon.build.common.maven.logging.PlexusLoggerHolder;
 
 import org.apache.maven.archiver.MavenArchiveConfiguration;
 import org.apache.maven.archiver.MavenArchiver;

--- a/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/maven/ServeMojo.java
+++ b/maven-plugins/sitegen-maven-plugin/src/main/java/io/helidon/build/maven/sitegen/maven/ServeMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.helidon.build.maven.sitegen.maven;
 
 import java.io.File;
 
-import io.helidon.build.common.maven.plugin.PlexusLoggerHolder;
+import io.helidon.build.common.maven.logging.PlexusLoggerHolder;
 import io.helidon.build.maven.sitegen.SiteServer;
 
 import org.apache.maven.plugin.AbstractMojo;


### PR DESCRIPTION
Move Plexus Logging support from common/maven-plugin into common/maven-logging to avoid dragging the JDK17 requirement of common/maven-plugin.