### PR TITLE
Update ubuntu image and caching action version

### DIFF
--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -97,7 +97,7 @@ runs:
         java-version: ${{ env.JAVA_VERSION }}
     - name: Cache local Maven repository (read-write)
       if: ${{ inputs.maven-cache == 'read-write' }}
-      uses: actions/cache@v4.0.2
+      uses: actions/cache@v4.2.3
       with:
         # See https://github.com/actions/toolkit/issues/713
         # Include must not match top level directories
@@ -111,7 +111,7 @@ runs:
           local-maven-
     - name: Cache local Maven repository (read-only)
       if: ${{ inputs.maven-cache == 'read-only' }}
-      uses: actions/cache/restore@v4.0.2
+      uses: actions/cache/restore@v4.2.3
       with:
         path: |
           .m2/repository/**/*.*
@@ -122,7 +122,7 @@ runs:
           local-maven-
     - name: Build cache (read-write)
       if: ${{ inputs.build-cache == 'read-write' }}
-      uses: actions/cache@v4.0.2
+      uses: actions/cache@v4.2.3
       with:
         path: |
           ./**/target/**
@@ -134,7 +134,7 @@ runs:
           build-cache-${{ github.run_id }}-
     - name: Build cache (read-only)
       if: ${{ inputs.build-cache == 'read-only' }}
-      uses: actions/cache/restore@v4.0.2
+      uses: actions/cache/restore@v4.2.3
       with:
         path: |
           ./**/target/**

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   create-cli-tag:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: release
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   create-cli-tag:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     environment: release
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ concurrency:
 
 jobs:
   create-tag:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     environment: release
     outputs:
       tag: ${{ steps.create-tag.outputs.tag }}
@@ -58,7 +58,7 @@ jobs:
       ref: ${{ needs.create-tag.outputs.tag }}
   release:
     needs: [ create-tag, validate ]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     environment: release
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ concurrency:
 
 jobs:
   create-tag:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: release
     outputs:
       tag: ${{ steps.create-tag.outputs.tag }}
@@ -58,7 +58,7 @@ jobs:
       ref: ${{ needs.create-tag.outputs.tag }}
   release:
     needs: [ create-tag, validate ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     environment: release
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,7 +44,7 @@ concurrency:
 jobs:
   copyright:
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -55,7 +55,7 @@ jobs:
           run: etc/scripts/copyright.sh
   checkstyle:
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -65,7 +65,7 @@ jobs:
           run: etc/scripts/checkstyle.sh
   shellcheck:
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -76,7 +76,7 @@ jobs:
           run: etc/scripts/shellcheck.sh
   build:
     timeout-minutes: 15
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -101,10 +101,10 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ ubuntu-20.04, windows-2022 ]
+        os: [ ubuntu-22.04, windows-2022 ]
         moduleSet: [ cli, cli-functional, archetype, linker, others ]
         include:
-          - { os: ubuntu-20.04, platform: linux }
+          - { os: ubuntu-22.04, platform: linux }
           - { os: windows-2022, platform: windows }
     runs-on: ${{ matrix.os }}
     name: tests/${{ matrix.moduleSet }}-${{ matrix.platform }}
@@ -125,7 +125,7 @@ jobs:
   spotbugs:
     needs: build
     timeout-minutes: 15
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -141,7 +141,7 @@ jobs:
   javadoc:
     needs: build
     timeout-minutes: 15
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -157,7 +157,7 @@ jobs:
   vscode-ext:
     needs: build
     timeout-minutes: 15
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -176,9 +176,9 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ ubuntu-20.04, windows-2022, macos-13 ]
+        os: [ ubuntu-22.04, windows-2022, macos-13 ]
         include:
-          - { os: ubuntu-20.04, platform: linux-amd64 }
+          - { os: ubuntu-22.04, platform: linux-amd64 }
           - { os: windows-2022, platform: windows-amd64, file-ext: .exe }
           - { os: macos-13, platform: darwin-amd64 }
     runs-on: ${{ matrix.os }}
@@ -213,7 +213,7 @@ jobs:
               -P tests \
               test
   cli-binaries:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [ build, cli ]
     name: cli/binaries
     steps:
@@ -222,7 +222,7 @@ jobs:
           name: helidon-cli
           pattern: "helidon-cli-{bin-*,dist}"
   test-results:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [ tests, cli ]
     name: tests/results
     steps:
@@ -231,7 +231,7 @@ jobs:
           name: test-results
           pattern: "*test*"
   gate:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [ copyright, checkstyle, shellcheck, spotbugs, javadoc, vscode-ext, cli-binaries, test-results ]
     steps:
       - shell: bash

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,7 +44,7 @@ concurrency:
 jobs:
   copyright:
     timeout-minutes: 5
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -55,7 +55,7 @@ jobs:
           run: etc/scripts/copyright.sh
   checkstyle:
     timeout-minutes: 5
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -65,7 +65,7 @@ jobs:
           run: etc/scripts/checkstyle.sh
   shellcheck:
     timeout-minutes: 5
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -76,7 +76,7 @@ jobs:
           run: etc/scripts/shellcheck.sh
   build:
     timeout-minutes: 15
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -101,10 +101,10 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ ubuntu-22.04, windows-2022 ]
+        os: [ ubuntu-24.04, windows-2022 ]
         moduleSet: [ cli, cli-functional, archetype, linker, others ]
         include:
-          - { os: ubuntu-22.04, platform: linux }
+          - { os: ubuntu-24.04, platform: linux }
           - { os: windows-2022, platform: windows }
     runs-on: ${{ matrix.os }}
     name: tests/${{ matrix.moduleSet }}-${{ matrix.platform }}
@@ -125,7 +125,7 @@ jobs:
   spotbugs:
     needs: build
     timeout-minutes: 15
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -141,7 +141,7 @@ jobs:
   javadoc:
     needs: build
     timeout-minutes: 15
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -157,7 +157,7 @@ jobs:
   vscode-ext:
     needs: build
     timeout-minutes: 15
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -176,9 +176,9 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ ubuntu-22.04, windows-2022, macos-13 ]
+        os: [ ubuntu-24.04, windows-2022, macos-13 ]
         include:
-          - { os: ubuntu-22.04, platform: linux-amd64 }
+          - { os: ubuntu-24.04, platform: linux-amd64 }
           - { os: windows-2022, platform: windows-amd64, file-ext: .exe }
           - { os: macos-13, platform: darwin-amd64 }
     runs-on: ${{ matrix.os }}
@@ -213,7 +213,7 @@ jobs:
               -P tests \
               test
   cli-binaries:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [ build, cli ]
     name: cli/binaries
     steps:
@@ -222,7 +222,7 @@ jobs:
           name: helidon-cli
           pattern: "helidon-cli-{bin-*,dist}"
   test-results:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [ tests, cli ]
     name: tests/results
     steps:
@@ -231,7 +231,7 @@ jobs:
           name: test-results
           pattern: "*test*"
   gate:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [ copyright, checkstyle, shellcheck, spotbugs, javadoc, vscode-ext, cli-binaries, test-results ]
     steps:
       - shell: bash


### PR DESCRIPTION
Fixes #1111

This PR updates caching action to version 4.2.3 to fix build. It also updates the Ubuntu image to 24.04 as 22 will be down on April 15th.

See https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#ubuntu-20-image-is-closing-down