### PR TITLE
Add XML-based support for .drawio file type

### DIFF
--- a/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorXml.java
+++ b/maven-plugins/enforcer-maven-plugin/src/main/java/io/helidon/build/maven/enforcer/copyright/ValidatorXml.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,8 @@ class ValidatorXml extends ValidatorBase {
                       ".xcs",
                       ".jsf",
                       ".hs",
-                      ".jhm");
+                      ".jhm",
+                      ".drawio");
     }
 
     @Override


### PR DESCRIPTION
Resolves #1130

`.drawio` files are XML internally, so the existing XML validation works for them.