### PR TITLE
Upgrade Jandex to 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
         <version.lib.invoker>3.3.0</version.lib.invoker>
         <version.lib.jackson>2.11.0</version.lib.jackson>
-        <version.lib.jandex>3.1.2</version.lib.jandex>
+        <version.lib.jandex>3.3.0</version.lib.jandex>
         <version.lib.jansi>1.18</version.lib.jansi>
         <version.lib.jaxb-api>2.3.3</version.lib.jaxb-api>
         <version.lib.jaxb-core>2.3.0.1</version.lib.jaxb-core>


### PR DESCRIPTION
Upgrades jandex to match what is used in Helidon 4.3.0

Fixes #1149 


