### PR TITLE
Fix Javadoc handling of invalid automatic modules

### DIFF
--- a/cli/impl/pom.xml
+++ b/cli/impl/pom.xml
@@ -194,7 +194,7 @@
                 <configuration>
                     <reuseForks>false</reuseForks>
                     <systemPropertyVariables>
-                        <helidon.test.version>2.5.0</helidon.test.version>
+                        <helidon.test.version>2.5.6</helidon.test.version>
                     </systemPropertyVariables>
                     <environmentVariables>
                         <formatEnv>%s</formatEnv>

--- a/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/module1/pom.xml
+++ b/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/module1/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.build-tools.javadoc.tests</groupId>
+        <artifactId>parent</artifactId>
+        <version>@project.version@</version>
+    </parent>
+    <artifactId>test-module1</artifactId>
+    <name>Test Javadoc 2 - Module 1</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.build-tools.javadoc.tests</groupId>
+            <artifactId>test-public-module2</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.build-tools.javadoc.tests</groupId>
+            <artifactId>test-public-module3</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/module1/src/main/java/com/acme1/Acme1.java
+++ b/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/module1/src/main/java/com/acme1/Acme1.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.acme1;
+
+/**
+ * Acme1.
+ * @see com.acme2.Acme2
+ * @see com.acme3.Acme3
+ */
+public class Acme1 {
+
+    private Acme1(){
+    }
+}

--- a/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/module2/pom.xml
+++ b/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/module2/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.build-tools.javadoc.tests</groupId>
+        <artifactId>parent</artifactId>
+        <version>@project.version@</version>
+    </parent>
+    <artifactId>test-public-module2</artifactId>
+    <name>Test Javadoc 2 - Module 2</name>
+</project>

--- a/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/module2/src/main/java/com/acme2/Acme2.java
+++ b/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/module2/src/main/java/com/acme2/Acme2.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.acme2;
+
+/**
+ * Acme2.
+ */
+public class Acme2 {
+
+    private Acme2(){
+    }
+}

--- a/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/module3/pom.xml
+++ b/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/module3/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.build-tools.javadoc.tests</groupId>
+        <artifactId>parent</artifactId>
+        <version>@project.version@</version>
+    </parent>
+    <artifactId>test-public-module3</artifactId>
+    <name>Test Javadoc 2 - Module 3</name>
+</project>

--- a/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/module3/src/main/java/com/acme3/Acme3.java
+++ b/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/module3/src/main/java/com/acme3/Acme3.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.acme3;
+
+/**
+ * Acme3.
+ */
+public class Acme3 {
+
+    private Acme3(){
+    }
+}

--- a/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/module4/pom.xml
+++ b/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/module4/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.build-tools.javadoc.tests</groupId>
+        <artifactId>parent</artifactId>
+        <version>@project.version@</version>
+    </parent>
+    <artifactId>test-module3</artifactId>
+    <name>Test Javadoc 2 - Module 4</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.build-tools.javadoc.tests</groupId>
+            <artifactId>test-module1</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.helidon.build-tools</groupId>
+                <artifactId>helidon-javadoc-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>javadoc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <fileExcludes>
+                        <exclude>*__*.java</exclude>
+                    </fileExcludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/module4/src/main/resources/test.properties
+++ b/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/module4/src/main/resources/test.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# exists to create a non-empty JAR file

--- a/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/pom.xml
+++ b/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.helidon.build-tools.javadoc.tests</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+    <name>Test Javadoc 2</name>
+    <packaging>pom</packaging>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module1</module>
+        <module>module2</module>
+        <module>module3</module>
+        <module>module4</module>
+    </modules>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.11.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/postbuild.groovy
+++ b/maven-plugins/javadoc-maven-plugin/src/it/projects/test2/postbuild.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.helidon.build.common.test.utils.JUnitLauncher
+import io.helidon.build.javadoc.ProjectsTestIT
+
+//noinspection GroovyAssignabilityCheck,GrUnresolvedAccess
+JUnitLauncher.builder()
+        .select(ProjectsTestIT.class, "test2", String.class)
+        .parameter("basedir", basedir.getAbsolutePath())
+        .reportsDir(basedir)
+        .outputFile(new File(basedir, "test.log"))
+        .suiteId("javadoc-it-test2")
+        .suiteDisplayName("Helidon Javadoc Maven Plugin Integration Test 2")
+        .build()
+        .launch()

--- a/maven-plugins/javadoc-maven-plugin/src/main/java/io/helidon/build/javadoc/JavadocModule.java
+++ b/maven-plugins/javadoc-maven-plugin/src/main/java/io/helidon/build/javadoc/JavadocModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,11 +40,6 @@ import static java.util.stream.Collectors.toSet;
 interface JavadocModule {
 
     /**
-     * The constant for the name of the modules without a {@link ModuleDescriptor}.
-     */
-    String INVALID = "INVALID!";
-
-    /**
      * The Maven artifact of this module.
      *
      * @return ArtifactInfo
@@ -68,11 +63,19 @@ interface JavadocModule {
     /**
      * Get this module name.
      *
-     * @return module name or {@link #INVALID} if {@link #descriptor()} is {@code null}
+     * @return module descriptor name or name derived from the Maven coordinates.
      */
     default String name() {
         ModuleDescriptor md = descriptor();
-        return md != null ? md.name() : INVALID;
+        if (md != null) {
+            return md.name();
+        }
+        String name = "coords:" + artifact().groupId() + ":" + artifact().artifactId();
+        String classifier = artifact().classifier();
+        if (classifier != null && !classifier.isBlank()) {
+            name += ":" + classifier;
+        }
+        return name;
     }
 
     /**

--- a/maven-plugins/javadoc-maven-plugin/src/main/java/io/helidon/build/javadoc/JavadocMojo.java
+++ b/maven-plugins/javadoc-maven-plugin/src/main/java/io/helidon/build/javadoc/JavadocMojo.java
@@ -19,6 +19,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.module.FindException;
 import java.lang.module.ModuleDescriptor;
 import java.lang.module.ModuleFinder;
 import java.lang.module.ModuleReference;
@@ -104,8 +105,8 @@ import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
 /**
- * A goal to produce javadocs.
- * Provides a <strong>simple</strong> way to produce aggregated javadocs.
+ * A goal to produce Javadocs.
+ * Provides a <strong>simple</strong> way to produce aggregated Javadocs.
  * <br/>
  * Project dependencies can be mapped to project modules, or downloaded via "sources" jar.
  * Only supports JDK >= 17.
@@ -545,11 +546,15 @@ public class JavadocMojo extends AbstractMojo {
                     module = new JarModule(artifact, moduleDescriptor(artifact), true);
                 }
             } catch (Throwable ex) {
-                Log.error(ex, "Unable to resolve javadoc module: %s (class-path only)", artifact);
-                if (LogLevel.isDebug()) {
-                    // Logging the full exception for troubleshooting
-                    Log.log(LogLevel.DEBUG, ex, "Unable to resolve javadoc module");
+                LogLevel level;
+                if (ex.getCause() instanceof IOException) {
+                    level = LogLevel.ERROR;
+                } else if (ex instanceof FindException) {
+                    level = LogLevel.DEBUG;
+                } else {
+                    level = LogLevel.ERROR;
                 }
+                Log.log(level, ex, "Unable to resolve javadoc module: %s (class-path only)", artifact);
                 module = new JarModule(artifact, null, true);
             }
 
@@ -560,10 +565,8 @@ public class JavadocMojo extends AbstractMojo {
                 computed = jars.compute(module.name(), module::merge);
             }
             if (computed instanceof CompositeJavadocModule cm) {
-                if (!cm.name().equals(JavadocModule.INVALID)) {
-                    Log.debug("Found module '%s' in multiple locations: %s",
-                            cm.name(), Lists.join(cm.artifacts(), MavenArtifact::file, " "));
-                }
+                Log.debug("Found module '%s' in multiple locations: %s",
+                        cm.name(), Lists.join(cm.artifacts(), MavenArtifact::file, " "));
             }
         }
     }
@@ -734,7 +737,15 @@ public class JavadocMojo extends AbstractMojo {
                     try {
                         return Stream.of(new JarModule(it, moduleDescriptor(it), false));
                     } catch (Throwable ex) {
-                        Log.error(ex, ex.getMessage());
+                        LogLevel level;
+                        if (ex.getCause() instanceof IOException) {
+                            level = LogLevel.ERROR;
+                        } else if (ex instanceof FindException) {
+                            level = LogLevel.DEBUG;
+                        } else {
+                            level = LogLevel.ERROR;
+                        }
+                        Log.log(level, ex, ex.getMessage());
                         return Stream.empty();
                     }
                 })

--- a/maven-plugins/javadoc-maven-plugin/src/test/java/io/helidon/build/javadoc/ProjectsTestIT.java
+++ b/maven-plugins/javadoc-maven-plugin/src/test/java/io/helidon/build/javadoc/ProjectsTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,5 +41,12 @@ class ProjectsTestIT {
         assertThat(apidocsDir.resolve("test.module2a/com/acme2a/Acme2a.html"), fileExists());
         assertThat(apidocsDir.resolve("test.module2a/com/acme2a/Acme2a__Excluded.html"), not(fileExists()));
         assertThat(apidocsDir.resolve("test.module2b/com/acme2b/Acme2b.html"), fileExists());
+    }
+
+    @ParameterizedTest
+    @ConfigurationParameterSource("basedir")
+    void test2(String basedir) {
+        Path apidocsDir = Path.of(basedir).resolve("module4/target/apidocs");
+        assertThat(apidocsDir.resolve("test.module1/com/acme1/Acme1.html"), fileExists());
     }
 }


### PR DESCRIPTION
## Summary

- Use Maven coordinates, including the classifier when present, as the fallback identity for JARs without a valid module descriptor so distinct invalid automatic modules are not merged.
- Log invalid automatic-module discovery failures at debug level while keeping I/O and unexpected resolution failures at error level.
- Add a regression integration project with two JARs that have invalid automatic module names and verify aggregated Javadocs are still generated.

## Validation

    mvn -pl maven-plugins/javadoc-maven-plugin -am clean verify -Pcheckstyle,copyright
